### PR TITLE
Change "Direita" to "Right" in align fields

### DIFF
--- a/src/components/panels/editing/activities/fields.ts
+++ b/src/components/panels/editing/activities/fields.ts
@@ -32,7 +32,7 @@ const groups = [
         props: {
           options: [
             {
-              label: 'Direita',
+              label: 'Right',
               value: 'right',
             },
             {

--- a/src/components/panels/editing/music/fields.ts
+++ b/src/components/panels/editing/music/fields.ts
@@ -35,7 +35,7 @@ const groups = [
         props: {
           options: [
             {
-              label: 'Direita',
+              label: 'Right',
               value: 'right',
             },
             {

--- a/src/components/panels/editing/profile-views/fields.ts
+++ b/src/components/panels/editing/profile-views/fields.ts
@@ -42,7 +42,7 @@ const groups = [
         props: {
           options: [
             {
-              label: 'Direita',
+              label: 'Right',
               value: 'right',
             },
             {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did

Match align fields translation for `activities`, `music` and `profile-views` with the rest of application.