### PR TITLE
FEAT: Adding a confirmation modal to improve UX

### DIFF
--- a/src/components/canvas/index.tsx
+++ b/src/components/canvas/index.tsx
@@ -7,7 +7,7 @@ import { sectionMap, BaseSection } from 'components';
 import { events } from 'app';
 import { useCanvas } from 'hooks';
 
-import { ContextMenus } from 'types';
+import { ContextMenus, Modals } from 'types';
 import * as S from './styles';
 
 const Canvas = () => {
@@ -22,7 +22,7 @@ const Canvas = () => {
   return (
     <S.Container onContextMenu={handleOpenContextMenu}>
       {!!sections.length && (
-        <S.ClearButton onClick={events.canvas.clear}>
+        <S.ClearButton onClick={() => events.modal.open(Modals.CONFIRM)}>
           <TrashIcon size={16} />
         </S.ClearButton>
       )}

--- a/src/components/modals/confirm/index.tsx
+++ b/src/components/modals/confirm/index.tsx
@@ -1,0 +1,24 @@
+import { events } from 'app';
+import { BaseModal } from '../base';
+
+import * as S from './styles';
+
+const ConfirmModal = () => {
+  return (
+    <BaseModal title="Are you sure you want to delete the created README?">
+      <S.Container>
+        <p>Upon confirming, you will delete the README you created.</p>
+        <S.Container>
+          <S.Row>
+            <S.ButtonCancel onClick={events.modal.close}>Cancel</S.ButtonCancel>
+            <S.Button onDelete onClick={events.canvas.clear}>
+              Yes, I am sure.
+            </S.Button>
+          </S.Row>
+        </S.Container>
+      </S.Container>
+    </BaseModal>
+  );
+};
+
+export { ConfirmModal };

--- a/src/components/modals/confirm/styles.ts
+++ b/src/components/modals/confirm/styles.ts
@@ -1,0 +1,35 @@
+import styled, { css } from 'styled-components';
+
+export const Container = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacings.xsmall};
+  `}
+`;
+
+export const Row = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+
+  & > button:last-child {
+    margin-left: 15px;
+  }
+`;
+
+export const ButtonCancel = styled.button`
+  border: 1px solid #fff;
+  padding: 5px 10px;
+  border-radius: 10px;
+`;
+
+export const Button = styled.button<{ onDelete: boolean }>`
+  ${({ onDelete }) => css`
+    border: 1px solid #f00;
+    padding: 5px 10px;
+    border-radius: 10px;
+    color: ${onDelete ? 'red' : 'auto'};
+  `}
+`;

--- a/src/components/modals/modals.ts
+++ b/src/components/modals/modals.ts
@@ -2,10 +2,12 @@ import { Modals } from 'types';
 
 import { ImproveSkillsModal } from './improve-skills';
 import { ShareModal } from './share';
+import { ConfirmModal } from './confirm';
 
 const modals = {
   [Modals.IMPROVE_SKILLS]: ImproveSkillsModal,
   [Modals.SHARE]: ShareModal,
+  [Modals.CONFIRM]: ConfirmModal,
 };
 
 export { modals };

--- a/src/types/modals.ts
+++ b/src/types/modals.ts
@@ -1,4 +1,5 @@
 export enum Modals {
   IMPROVE_SKILLS = 'improve-skills',
   SHARE = 'share',
+  CONFIRM = 'confirm',
 }


### PR DESCRIPTION
### Problem:
When I was using the application, I clicked on the delete icon and deleted everything I had created.

### Solution:
With the user experience in mind, I implemented a confirmation modal that ensures that no one will be able to accidentally delete the README.

### I kept the application design in the modal to ensure a good UI.
![image](https://user-images.githubusercontent.com/81381789/173984502-2119f5ac-637d-4658-86de-66a9fb683bd5.png)

### Code pattern
Also, I kept the code pattern used by you, Mauro.

Hope you enjoyed and approve this PR. Thanks!
