### PR TITLE
fix: application crashes when attempting to right-click an element

### DIFF
--- a/src/components/context-menus/section/index.tsx
+++ b/src/components/context-menus/section/index.tsx
@@ -14,16 +14,15 @@ const SectionContextMenu = ({ event }: SectionContextMenuProps) => {
   const canShow = () => {
     const range = 5;
 
-    const { nativeEvent } = event;
-    const elements = (nativeEvent as any).path;
-
     let sectionId = '';
+    let currentElement = event.target as HTMLElement;
     let currentIndex = 0;
 
     while (!sectionId && currentIndex < range) {
-      const section = elements[currentIndex] as HTMLElement;
-
-      sectionId = section.dataset.sectionid!;
+      sectionId = currentElement.getAttribute('data-sectionid') || '';
+      if (!sectionId && currentElement.parentElement) {
+        currentElement = currentElement.parentElement;
+      }
       currentIndex += 1;
     }
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did
### Summery
this pr fixed #8 .
### Details
Every attempt to right click an element generate this exception,  this bug practically prevents users from using this useful application (users cannot delete elements unless all elements are cleared).  
I located this bug in `src/components/context-menus/section/index.tsx`, thus I updated the logic for locating the element with data-sectionid.
### Preview
![preview](https://user-images.githubusercontent.com/37903575/215858450-d299059b-f967-44d7-b35f-84987ab7f312.gif)
