### PR TITLE
✨ feat: copy button for generated readme

### DIFF
--- a/src/components/helpers/index.ts
+++ b/src/components/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from './portal';
+export * from './only-client-side';

--- a/src/components/helpers/only-client-side.tsx
+++ b/src/components/helpers/only-client-side.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+type OnlyClientSideProps = {
+  children: React.ReactNode;
+};
+
+const OnlyClientSide = ({ children }: OnlyClientSideProps) => {
+  const [canRender, setCanRender] = useState(false);
+  useEffect(() => {
+    setCanRender(true);
+  }, []);
+
+  return canRender ? <>{children}</> : null;
+};
+
+export { OnlyClientSide };

--- a/src/components/readme-result/actions.ts
+++ b/src/components/readme-result/actions.ts
@@ -1,0 +1,12 @@
+import { Copy } from '@styled-icons/feather';
+import { copyToClipboard } from 'utils';
+
+const actions = [
+  {
+    label: 'Copy',
+    icon: Copy,
+    action: (content: string) => copyToClipboard(content),
+  },
+];
+
+export { actions };

--- a/src/components/readme-result/index.tsx
+++ b/src/components/readme-result/index.tsx
@@ -4,6 +4,9 @@ import primsjs from 'prismjs';
 import { events } from 'app';
 import { Events } from 'types';
 
+import { Tooltip } from 'components';
+
+import { actions } from './actions';
 import * as S from './styles';
 
 const ReadmeResult = () => {
@@ -27,6 +30,18 @@ const ReadmeResult = () => {
 
   return (
     <S.Container ref={containerRef}>
+      <S.Actions>
+        {actions.map(({ label, icon: Icon, action }, i) => (
+          <Tooltip key={i} content={label} position="top">
+            <li>
+              <S.Action onClick={() => action(content)}>
+                <Icon size={16} />
+              </S.Action>
+            </li>
+          </Tooltip>
+        ))}
+      </S.Actions>
+
       <pre className={`language-html`}>
         <code className={`language-html`}>{content}</code>
       </pre>

--- a/src/components/readme-result/styles.ts
+++ b/src/components/readme-result/styles.ts
@@ -2,7 +2,6 @@ import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
   ${({ theme }) => css`
-    user-select: all;
     position: relative;
     width: 100%;
     padding: ${theme.spacings.xlarge};
@@ -85,6 +84,35 @@ export const Container = styled.div`
 
     pre {
       background: transparent;
+    }
+  `}
+`;
+
+export const Actions = styled.ul`
+  ${({ theme }) => css`
+    position: absolute;
+    top: ${theme.spacings.xlarge};
+    right: ${theme.spacings.xlarge};
+    display: flex;
+  `}
+`;
+
+export const Action = styled.button`
+  ${({ theme }) => css`
+    padding: ${theme.spacings.xsmall};
+    border-radius: 10rem;
+    border-width: ${theme.border.width};
+    border-color: ${theme.colors.border};
+    border-style: solid;
+    display: grid;
+    place-items: center;
+
+    & * {
+      cursor: pointer;
+    }
+
+    &:hover {
+      filter: brightness(2);
     }
   `}
 `;

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -16,7 +16,7 @@ type TooltipProps = {
 const Tooltip = ({
   children,
   position = 'top',
-  variant = 'info',
+  variant = 'default',
   content,
 }: TooltipProps) => {
   const openTimetouRef = useRef<NodeJS.Timeout>();

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from 'styled-components';
 
-import { Portal } from 'components';
+import { OnlyClientSide, Portal } from 'components';
 import { TooltipPositions, TooltipVariants } from 'types';
 
 import * as S from './styles';
@@ -19,19 +19,41 @@ const Tooltip = ({
   variant = 'info',
   content,
 }: TooltipProps) => {
+  const openTimetouRef = useRef<NodeJS.Timeout>();
+  const closeTimetouRef = useRef<NodeJS.Timeout>();
+
   const childrenRef = useRef<Element>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
 
-  const [childreRect, setChildreRect] = useState<DOMRect>({} as DOMRect);
-  const [tooltipRect, setTooltipRect] = useState<DOMRect>({} as DOMRect);
+  const [coordinate, setCoordinate] = useState({ x: 0, y: 0 });
 
   const [open, setOpen] = useState(false);
+  const [mount, setMount] = useState(false);
+
   const theme = useTheme();
 
-  const handleMouseEnter = () => setOpen(true);
-  const handleMouseLeave = () => setOpen(false);
+  const handleMouseLeave = () => {
+    setOpen(false);
+
+    closeTimetouRef.current = setTimeout(() => {
+      setMount(false);
+    }, 350);
+  };
+
+  const handleMouseEnter = () => {
+    clearTimeout(closeTimetouRef.current!);
+    setMount(true);
+
+    openTimetouRef.current = setTimeout(() => {
+      getPosition();
+      setOpen(true);
+    });
+  };
 
   const getPosition = () => {
+    const childreRect = childrenRef.current!.getBoundingClientRect();
+    const tooltipRect = tooltipRef.current!.getBoundingClientRect();
+
     const space = Number(theme.spacings.xsmall.replace(/\D/g, ''));
 
     const middleXTooltip = tooltipRect.width / 2;
@@ -57,10 +79,10 @@ const Tooltip = ({
       keyof typeof positionsX
     ];
 
-    return {
-      x: positionsX[x] ?? middleX,
-      y: positionsY[y] ?? middleY,
-    };
+    setCoordinate({
+      x: (positionsX[x] ?? middleX) || 0,
+      y: (positionsY[y] ?? middleY) || 0,
+    });
   };
 
   const childrenProps = {
@@ -70,28 +92,29 @@ const Tooltip = ({
   };
 
   useEffect(() => {
-    const childrenPositions = childrenRef.current!.getBoundingClientRect();
-    const tooltipPositions = tooltipRef.current!.getBoundingClientRect();
-
-    setChildreRect(childrenPositions);
-    setTooltipRect(tooltipPositions);
-  }, [content]);
+    return () => {
+      clearTimeout(openTimetouRef.current!);
+      clearTimeout(closeTimetouRef.current!);
+    };
+  }, []);
 
   return (
-    <>
+    <OnlyClientSide>
       {React.cloneElement(children, childrenProps)}
 
-      <Portal>
-        <S.Container
-          ref={tooltipRef}
-          open={open}
-          variant={variant}
-          {...getPosition()}
-        >
-          {content}
-        </S.Container>
-      </Portal>
-    </>
+      {mount && (
+        <Portal>
+          <S.Container
+            ref={tooltipRef}
+            open={open}
+            variant={variant}
+            {...coordinate}
+          >
+            {content}
+          </S.Container>
+        </Portal>
+      )}
+    </OnlyClientSide>
   );
 };
 

--- a/src/components/tooltip/styles.ts
+++ b/src/components/tooltip/styles.ts
@@ -1,5 +1,16 @@
-import styled, { css, DefaultTheme } from 'styled-components';
+import styled, {
+  css,
+  DefaultTheme,
+  FlattenSimpleInterpolation,
+} from 'styled-components';
+
 import { TooltipVariants } from 'types';
+
+type ContainerModifiers = {
+  [key in TooltipVariants]?: (
+    theme: DefaultTheme
+  ) => FlattenSimpleInterpolation;
+};
 
 type ContainerProps = {
   open: boolean;
@@ -12,6 +23,15 @@ const backgroundsMap: Record<TooltipVariants, keyof DefaultTheme['colors']> = {
   [TooltipVariants.DANGER]: 'error',
   [TooltipVariants.SUCCESS]: 'secondary',
   [TooltipVariants.INFO]: 'primary',
+  [TooltipVariants.DEFAULT]: 'bg',
+};
+
+const containerModifiers: ContainerModifiers = {
+  [TooltipVariants.DEFAULT]: (theme: DefaultTheme) => css`
+    border-width: ${theme.border.width};
+    border-color: ${theme.colors.border};
+    border-style: solid;
+  `,
 };
 
 export const Container = styled.span<ContainerProps>`
@@ -29,5 +49,7 @@ export const Container = styled.span<ContainerProps>`
 
     opacity: ${open ? 1 : 0};
     pointer-events: ${open ? 'all' : 'none'};
+
+    ${containerModifiers[variant] && containerModifiers[variant]!(theme)}
   `}
 `;

--- a/src/components/tooltip/styles.ts
+++ b/src/components/tooltip/styles.ts
@@ -23,7 +23,7 @@ export const Container = styled.span<ContainerProps>`
     position: absolute;
     top: ${y}px;
     left: ${x}px;
-    padding: 4px 6px;
+    padding: calc(${theme.spacings.xsmall} / 2) ${theme.spacings.xsmall};
     border-radius: ${theme.border.radius};
     transition: opacity 0.3s;
 

--- a/src/hooks/use-outside-click.ts
+++ b/src/hooks/use-outside-click.ts
@@ -8,8 +8,6 @@ const useOutsideClick = (
   opened: boolean
 ) => {
   const handleOutsideClick = (event: Event) => {
-    console.log(event.target);
-
     const refs = Array.isArray(els) ? els : [els];
 
     const outsideClick = refs.every(

--- a/src/types/tooltip.ts
+++ b/src/types/tooltip.ts
@@ -13,4 +13,5 @@ export enum TooltipVariants {
   INFO = 'info',
   SUCCESS = 'success',
   DANGER = 'danger',
+  DEFAULT = 'default',
 }

--- a/src/utils/copyToClipboard/index.ts
+++ b/src/utils/copyToClipboard/index.ts
@@ -1,0 +1,5 @@
+const copyToClipboard = async (string: string) => {
+  await navigator.clipboard.writeText(string);
+};
+
+export { copyToClipboard };

--- a/src/utils/copyToClipboard/test.ts
+++ b/src/utils/copyToClipboard/test.ts
@@ -1,0 +1,22 @@
+import { copyToClipboard } from '.';
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: () => null,
+  },
+});
+
+jest.spyOn(navigator.clipboard, 'writeText');
+
+describe('UTILS - Copy to clip board', () => {
+  const input = 'some value';
+
+  beforeAll(() => {
+    copyToClipboard(input);
+  });
+
+  it('should be called with the correct value', () => {
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(input);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,3 +13,4 @@ export * from './getStatsUrl';
 export * from './getPanelSideEvent';
 export * from './getActivitiesUrl';
 export * from './getMusicUrl';
+export * from './copyToClipboard';


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation Update

## What I did

I added a copy button to generated readme.

Also was made a improves in opening/closing of tooltip, now, ever mouse enter/leave will mount/unmount the tooltip in document, too was added a new variant, called default.

![image](https://user-images.githubusercontent.com/54520907/217420148-f1a4a456-6298-4a5e-a44d-763f66a1fc47.png)

Closes #15 
