### PR TITLE
🐛 fix: GitHub raw URL for snake animation

### DIFF
--- a/src/generators/readme/sections/snake.ts
+++ b/src/generators/readme/sections/snake.ts
@@ -6,7 +6,7 @@ const generateSnakeSection = (
 ) => {
   const { github } = settings.user;
 
-  return `<img src="https://raw.githubusercontent.com/${github}/${github}/blob/output/snake.svg" alt="Snake animation"/>`;
+  return `<img src="https://raw.githubusercontent.com/${github}/${github}/output/snake.svg" alt="Snake animation"/>`;
 };
 
 export { generateSnakeSection };


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug Fix

## What I did

Changed the GitHub raw user content URL for snake animation to not include `blob` as it does not work anymore and returns a `404`
