### PR TITLE
🐛  fix: disable count api

### DIFF
--- a/src/pages/api/count.ts
+++ b/src/pages/api/count.ts
@@ -44,7 +44,7 @@ const handles = {
 };
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (environment !== 'production') return res.status(StatusCode.OK).json({});
+  if (environment) return res.status(StatusCode.OK).json({});
 
   const allowedMethods = [HTTPMethods.GET, HTTPMethods.PUT];
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did

I implemented a count metric to see the main page visits and the number of generated readmes, but apparently, it has been down since April.

With it, it is generating a timeout error on the Vercel API, throwing a lot of error messages in the panel.

So, I decided just to remove this part for a while. Now, it will just return 200 when it has been called.

Closes #54 
