### PR TITLE
feat: update copy lable when user copies the result

### DIFF
--- a/src/components/readme-result/index.tsx
+++ b/src/components/readme-result/index.tsx
@@ -27,14 +27,23 @@ const ReadmeResult = () => {
       events.off(Events.RESULT_SHOW_CONTENT, handleShowContent);
     };
   }, []);
+  const [labelVal, setlabelVal] = useState('Copy')
+
+  // updates the copy label when user copies the content
+  const updateLable = ()=>{
+    setlabelVal('Copied!')
+    setTimeout(() => {
+      setlabelVal('Copy')
+    }, 3000);
+  }
 
   return (
     <S.Container ref={containerRef}>
       <S.Actions>
-        {actions.map(({ label, icon: Icon, action }, i) => (
-          <Tooltip key={i} content={label} position="top">
+        {actions.map(({ icon: Icon, action}, i) => (
+          <Tooltip key={i} content={labelVal} position="top">
             <li>
-              <S.Action onClick={() => action(content)}>
+              <S.Action onClick={() => { action(content); updateLable()}}>
                 <Icon size={16} />
               </S.Action>
             </li>


### PR DESCRIPTION
✨ feat: update copy lable when user copies the result;

when the user clicks on the copy button on the result page once the result gets copied we'll see the label change from copy to copied! this improves the UI by giving user some feedback after copying is done

Fixes #42

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation Update

## What I did
added code to change label of copy button from copy to copied! when the user copies the result
<!--
  A clear and concise description of what you did. If applicable, add screenshots/gifs to show your UI changes
 -->
