### PR TITLE
✨ feat: add light/dark theme switch

### DIFF
--- a/src/app/events/handles/canvas.ts
+++ b/src/app/events/handles/canvas.ts
@@ -45,6 +45,10 @@ class CanvasHandleEvents extends BaseEventHandle {
   currentSection = (sectionId: string) => {
     this.emit(Events.CANVAS_SET_CURRENT_SECTION, sectionId);
   };
+
+  switchTheme = (theme: boolean) => {
+    this.emit(Events.CANVAS_SWITCH_THEME, theme);
+  };
 }
 
 export { CanvasHandleEvents };

--- a/src/components/canvas/index.tsx
+++ b/src/components/canvas/index.tsx
@@ -4,6 +4,8 @@ import { Reorder } from 'framer-motion';
 import {
   Trash as TrashIcon,
   Check as CheckIcon,
+  Moon as MoonIcon,
+  Sun as SunIcon,
   X as CloseIcon,
 } from '@styled-icons/feather';
 
@@ -24,7 +26,7 @@ import { CanvasErrorFallback } from './error';
 
 const Canvas = () => {
   const { extensions } = useExtensions();
-  const { sections, currentSection, previewMode } = useCanvas();
+  const { sections, currentSection, previewMode, lightTheme } = useCanvas();
   const [hasError, setHasError] = useState(false);
 
   const sectionIds = sections.map(section => section.id);
@@ -41,9 +43,26 @@ const Canvas = () => {
       <S.Container
         onContextMenu={handleOpenContextMenu}
         fullHeight={hasError || !hasSection}
+        isLightTheme={lightTheme}
       >
+        <S.Wrapper isLeftAligned={false}>
+          <Tooltip
+            position="right"
+            content={`Preview: ${lightTheme ? 'dark' : 'light'} mode`}
+            variant="info"
+          >
+            <S.Button
+              aria-label={`Preview: ${lightTheme ? 'dark' : 'light'} mode`}
+              onClick={() => events.canvas.switchTheme(lightTheme)}
+              variant="success"
+            >
+              {lightTheme ? <MoonIcon size={16} /> : <SunIcon size={16} />}
+            </S.Button>
+          </Tooltip>
+        </S.Wrapper>
+
         {hasSection && !previewMode && (
-          <S.Wrapper>
+          <S.Wrapper isLeftAligned={true}>
             <Tooltip position="left" content="Clear canvas" variant="danger">
               <S.Button
                 aria-label="Clear canvas"
@@ -61,7 +80,7 @@ const Canvas = () => {
           onChange={setHasError}
         >
           {previewMode && (
-            <S.Wrapper>
+            <S.Wrapper isLeftAligned={true}>
               <Tooltip position="left" content="Use template" variant="success">
                 <S.Button
                   aria-label="Use template"

--- a/src/components/canvas/styles.ts
+++ b/src/components/canvas/styles.ts
@@ -2,10 +2,15 @@ import styled, { css, DefaultTheme } from 'styled-components';
 
 type ContainerProps = {
   fullHeight: boolean;
+  isLightTheme: boolean;
+};
+
+type WrapperProps = {
+  isLeftAligned: boolean;
 };
 
 export const Container = styled.div<ContainerProps>`
-  ${({ theme, fullHeight }) => css`
+  ${({ theme, fullHeight, isLightTheme }) => css`
     padding: ${theme.spacings.xlarge};
     border-radius: ${theme.border.radius};
     border-width: ${theme.border.width};
@@ -15,6 +20,10 @@ export const Container = styled.div<ContainerProps>`
     overflow-y: scroll;
     padding-right: ${theme.spacings.small};
     height: ${fullHeight ? '100%' : 'auto'};
+
+    background: ${isLightTheme && '#eee'};
+    color: ${isLightTheme && theme.colors.bg};
+    transition: color 0.25s linear, background 0.25s linear;
 
     &::-webkit-scrollbar {
       width: 0.8rem;
@@ -31,8 +40,8 @@ export const Container = styled.div<ContainerProps>`
   `}
 `;
 
-export const Wrapper = styled.div`
-  ${({ theme }) => css`
+export const Wrapper = styled.div<WrapperProps>`
+  ${({ theme, isLeftAligned }) => css`
     width: 3rem;
     position: absolute;
     display: flex;
@@ -44,7 +53,7 @@ export const Wrapper = styled.div`
     color: ${theme.colors.text};
 
     top: ${theme.spacings.medium};
-    left: 0;
+    left: ${isLeftAligned ? '0%' : '100%'};
     transform: translateX(-50%);
     transition: 0.3s;
 
@@ -73,6 +82,12 @@ const buttonModifiers = {
   success: (theme: DefaultTheme) => css`
     &:hover {
       color: ${theme.colors.secondary};
+    }
+  `,
+
+  info: (theme: DefaultTheme) => css`
+    &:hover {
+      color: ${theme.colors.primary};
     }
   `,
 };

--- a/src/contexts/canvas.tsx
+++ b/src/contexts/canvas.tsx
@@ -18,6 +18,7 @@ type CanvasContextData = {
   sections: CanvasSection[];
   currentSection?: CanvasSection;
   previewMode: boolean;
+  lightTheme: boolean;
 };
 
 type CanvasProviderProps = {
@@ -32,6 +33,7 @@ const CanvasProvider = ({ children }: CanvasProviderProps) => {
     []
   );
 
+  const [lightTheme, setLightTheme] = useState(false);
   const [currentSection, setCurrentSection] = useState<CanvasSection>();
   const [previewTemplate, setPreviewTemplate] = useState<CanvasSection[]>([]);
 
@@ -135,6 +137,10 @@ const CanvasProvider = ({ children }: CanvasProviderProps) => {
 
   const handleClearCanvas = () => setSections([]);
 
+  const handleSwitchTheme = () => {
+    setLightTheme(!lightTheme);
+  };
+
   useEffect(() => {
     // Canvas events
 
@@ -144,6 +150,7 @@ const CanvasProvider = ({ children }: CanvasProviderProps) => {
     events.on(Events.CANVAS_REORDER_SECTIONS, handleReorderSections);
     events.on(Events.CANVAS_DUPLICATE_SECTION, handleDuplicateSection);
     events.on(Events.CANVAS_CLEAR_SECTIONS, handleClearCanvas);
+    events.on(Events.CANVAS_SWITCH_THEME, handleSwitchTheme);
 
     return () => {
       events.off(Events.CANVAS_EDIT_SECTION, handleEditSection);
@@ -152,8 +159,9 @@ const CanvasProvider = ({ children }: CanvasProviderProps) => {
       events.off(Events.CANVAS_REORDER_SECTIONS, handleReorderSections);
       events.off(Events.CANVAS_DUPLICATE_SECTION, handleDuplicateSection);
       events.off(Events.CANVAS_CLEAR_SECTIONS, handleClearCanvas);
+      events.off(Events.CANVAS_SWITCH_THEME, handleSwitchTheme);
     };
-  }, [sections, currentSection]);
+  }, [sections, currentSection, lightTheme]);
 
   useEffect(() => {
     // Canvas events
@@ -182,7 +190,12 @@ const CanvasProvider = ({ children }: CanvasProviderProps) => {
 
   return (
     <CanvasContext.Provider
-      value={{ sections: canvas, currentSection, previewMode }}
+      value={{
+        sections: canvas,
+        currentSection,
+        previewMode,
+        lightTheme: lightTheme,
+      }}
     >
       {children}
     </CanvasContext.Provider>

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -6,6 +6,7 @@ export enum Events {
   CANVAS_REORDER_SECTIONS = 'canvas.section.reorder',
   CANVAS_DUPLICATE_SECTION = 'canvas.section.duplicate',
   CANVAS_CLEAR_SECTIONS = 'canvas.clear',
+  CANVAS_SWITCH_THEME = 'canvas.switchTheme',
 
   TEMPLATE_USE = 'template.use',
   TEMPLATE_PREVIEW = 'template.preview',


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

Hello!

For this feature I tried to apply as little changes to codebase as possible. In case of any doubts / questions about this PR, please let me know. Also I would really appreciate any related feedback. If this PR need some fixes before accepting, I am fine making additional changes to it.

Fixes: #44

<hr>
<br>

## What type of PR is this? (check all applicable)

- [ ] Refactor
-  [x]  Feature
- [ ] Bug Fix
-  [x]  Enhancement
- [ ] Documentation Update

## What I did

I have added a new button that makes toggling between canvas themes a smooth experience. The button is responsible for changing the canvas background color and text color. No other canvas appliances (like images, icons, etc.) are affected. By hovering over it, user can see a short message of what would happen after pressing the switch. 

Take a look at below screenshots to see the feature in action:

<br>

**Initial state (on load):**

![Screenshot1](https://github.com/maurodesouza/profile-readme-generator/assets/76244675/4754b0b8-6c1e-4141-974e-23baed1e8f66)


**Before pressing (on hover):**

![Screenshot2](https://github.com/maurodesouza/profile-readme-generator/assets/76244675/936c853a-7bbf-45a1-972c-2bf61e9bc565)

**After pressing (on hover):**

![Screenshot3](https://github.com/maurodesouza/profile-readme-generator/assets/76244675/559469ec-6f13-41d6-8fca-7e2f191d1b1e)

<br>

Original commit message: 

<br>

```
✨ feat: add light/dark theme switch

Include a new switch button that allows users to
preview their README files for both light and
dark themes (default theme is dark one).

This feature aims to reduce the issue with black
colored icons (mostly devicons / simple icons)
being barely visible on the dark canvas. Also it
is a nice UX enhancement for those users who
simply prefer light theming.

Fixes: #44
```


<!--
  A clear and concise description of what you did. If applicable, add screenshots/gifs to show your UI changes
 -->
