### PR TITLE
🐛 fix: Rust lang broken icon link

### DIFF
--- a/src/resources/tech_icons.ts
+++ b/src/resources/tech_icons.ts
@@ -5992,9 +5992,9 @@ const tech_icons = [
         path: 'https://img.shields.io/badge/Rust-000000?logo=rust&logoColor=white&style=for-the-badge',
       },
       devicons: {
-        path: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/rust/rust-plain.svg',
+        path: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/rust/rust-original.svg',
         variants: [
-          'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/rust/rust-plain.svg',
+          'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/rust/rust-original.svg',
         ],
       },
     },


### PR DESCRIPTION

## What type of PR is this?


- [x] Bug Fix


## What I did

Changed the Rust language icon URL  as it does not work anymore and returns a `404`

