### PR TITLE
🐛 fix: rstudio ide broken icon link from simpleicons provider

### DIFF
--- a/src/resources/tech_icons.ts
+++ b/src/resources/tech_icons.ts
@@ -5921,7 +5921,7 @@ const tech_icons = [
     available_providers: ['simple_icons', 'shields', 'devicons'],
     providers: {
       simple_icons: {
-        path: 'https://cdn.simpleicons.org/rstudio/75AADB',
+        path: 'https://cdn.simpleicons.org/rstudioide/75AADB',
       },
       shields: {
         path: 'https://img.shields.io/badge/RStudio-75AADB?logo=rstudio&logoColor=black&style=for-the-badge',


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Bug Fix


## What I did

updated broken icon link from simpleicons provider
