### PR TITLE
🐛 fix: update workflow default branch to main

### DIFF
--- a/src/features/snake/parser.ts
+++ b/src/features/snake/parser.ts
@@ -18,7 +18,7 @@ on:
 
   push:
     branches:
-    - master
+    - main
 
 jobs:
   generate:


### PR DESCRIPTION
Update snake workflow to use 'main' instead of 'master' as the default branch name to match GitHub's profile README default.
Fixes #73

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did
- Updated the snake workflow generator to use 'main' instead of 'master' as the default branch name
- This change aligns with GitHub's default branch naming convention for profile READMEs
- Fixed in snakeWorkflowParser function to ensure generated workflow uses correct branch name