### PR TITLE
Add support for light and dark mode

### DIFF
--- a/src/features/pacman/parser.ts
+++ b/src/features/pacman/parser.ts
@@ -3,7 +3,11 @@ import { Settings } from 'types';
 const pacmanSectionParser = (_: Record<string, unknown>, settings: Settings) => {
   const { github } = settings.user;
 
-  return `<img src="https://raw.githubusercontent.com/${github}/${github}/output/pacman-contribution-graph.svg" alt="Pacman animation"/>`;
+  return `<picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/${github}/${github}/output/pacman-contribution-graph-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/${github}/${github}/output/pacman-contribution-graph.svg">
+    <img alt="pacman contribution graph" src="https://raw.githubusercontent.com/${github}/${github}/output/pacman-contribution-graph.svg">
+</picture>`;
 };
 
 const pacmanWorkflowParser = () => {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did
The existing code only shows light mode picture.  
I added the ability to support both light and dark mode image display.  
Check `Step 3: Add the Pac-Man Graph to Your Profile README ` section in [Integrate Pac-Man Contribution Graph into Your GitHub Profile](https://abozanona.me/integrate-pacman-contribution-graph-into-github/).

<!--
  A clear and concise description of what you did. If applicable, add screenshots/gifs to show your UI changes
 -->
