### PR TITLE
⚡ chore: replace @styled-icons/feather with lucide

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "analyze": "ANALYZE=true yarn build"
   },
   "dependencies": {
-    "@styled-icons/feather": "^10.47.0",
     "framer-motion": "^12.12.1",
     "gray-matter": "^4.0.3",
     "html-prettify": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "framer-motion": "^12.12.1",
     "gray-matter": "^4.0.3",
     "html-prettify": "^1.0.7",
+    "lucide-react": "^0.511.0",
     "next": "^15.3.2",
     "next-compose-plugins": "^2.2.1",
     "next-pwa": "^5.6.0",

--- a/src/components/canvas/index.tsx
+++ b/src/components/canvas/index.tsx
@@ -2,22 +2,16 @@ import { MouseEvent, useMemo, useState } from 'react';
 import { Reorder } from 'framer-motion';
 
 import {
-  Trash as TrashIcon,
-  Check as CheckIcon,
-  X as CloseIcon,
-  Settings,
-} from '@styled-icons/feather';
-
-import { useCanvas, useExtensions } from 'hooks';
-import {
   BaseSection,
   Tooltip,
   Welcome,
   OnlyClientSide,
   ErrorBoundary,
 } from 'components';
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 import { events } from 'app';
+import { useCanvas, useExtensions } from 'hooks';
 import { ContextMenus, PanelsEnum } from 'types';
 
 import * as S from './styles';
@@ -51,7 +45,7 @@ const Canvas = () => {
                 onClick={events.canvas.clear}
                 variant="warn"
               >
-                <TrashIcon size={16} />
+                <Icon name="trash" />
               </S.Button>
             </Tooltip>
 
@@ -67,7 +61,7 @@ const Canvas = () => {
                 }
                 variant="info"
               >
-                <Settings size={16} />
+                <Icon name="settings" />
               </S.Button>
             </Tooltip>
           </S.Wrapper>
@@ -85,7 +79,7 @@ const Canvas = () => {
                   onClick={events.template.use}
                   variant="success"
                 >
-                  <CheckIcon size={16} />
+                  <Icon name="check" />
                 </S.Button>
               </Tooltip>
 
@@ -95,7 +89,7 @@ const Canvas = () => {
                   onClick={() => events.template.preview()}
                   variant="warn"
                 >
-                  <CloseIcon size={16} />
+                  <Icon name="x" />
                 </S.Button>
               </Tooltip>
             </S.Wrapper>

--- a/src/components/context-menus/section/actions.ts
+++ b/src/components/context-menus/section/actions.ts
@@ -1,20 +1,19 @@
 import { events } from 'app';
-import { Trash, Edit2, Copy } from '@styled-icons/feather';
 
 const actions = [
   {
     label: 'Duplicate',
-    icon: Copy,
+    icon: 'copy',
     action: events.canvas.duplicate,
   },
   {
     label: 'Edit',
-    icon: Edit2,
+    icon: 'edit-2',
     action: events.canvas.currentSection,
   },
   {
     label: 'Delete',
-    icon: Trash,
+    icon: 'trash',
     action: events.canvas.remove,
     variant: 'danger',
   },

--- a/src/components/context-menus/section/index.tsx
+++ b/src/components/context-menus/section/index.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef } from 'react';
+import { IconName } from 'lucide-react/dynamic';
 
 import { events } from 'app';
 import { DefaultContextMenuProps } from '../base';
 
 import { actions } from './actions';
 import * as S from './styles';
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 type SectionContextMenuProps = DefaultContextMenuProps;
 
@@ -36,7 +38,7 @@ const SectionContextMenu = ({ event }: SectionContextMenuProps) => {
 
   return (
     <S.Container>
-      {actions.map(({ label, icon: Icon, action, ...rest }) => (
+      {actions.map(({ label, icon, action, ...rest }) => (
         <S.Action
           key={label}
           onClick={() => [
@@ -48,7 +50,7 @@ const SectionContextMenu = ({ event }: SectionContextMenuProps) => {
           {label}
 
           <S.WrapperIcon>
-            <Icon size={16} />
+            <Icon name={icon as IconName} />
           </S.WrapperIcon>
         </S.Action>
       ))}

--- a/src/components/edit-social-item/index.tsx
+++ b/src/components/edit-social-item/index.tsx
@@ -1,11 +1,10 @@
 import { useState, useImperativeHandle, forwardRef, useEffect } from 'react';
 import { useDragControls, usePresence } from 'framer-motion';
 
-import { Menu } from '@styled-icons/feather';
+import { GroupFields } from 'components';
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 import { events } from 'app';
-import { GroupFields } from 'components';
-
 import { getSocialImgUrl } from 'utils';
 import { variants, animations } from './animations';
 
@@ -77,7 +76,7 @@ const EditSocialItem: React.ForwardRefRenderFunction<
             dragControls.start(event),
           ]}
         >
-          <Menu />
+          <Icon name="menu" size={20} />
         </S.Drag>
 
         <S.Logo
@@ -89,10 +88,14 @@ const EditSocialItem: React.ForwardRefRenderFunction<
         <S.Wrapper>
           <S.Name>{short_name || social}</S.Name>
 
-          <S.DeleteIcon size={16} onClick={handleDeleteSocial} />
+          <S.DeleteButton onClick={handleDeleteSocial}>
+            <Icon name="trash" />
+          </S.DeleteButton>
         </S.Wrapper>
 
-        <S.EditIcon size={16} onClick={handleToggleEditForm} />
+        <S.EditButton onClick={handleToggleEditForm}>
+          <Icon name="edit-2" />
+        </S.EditButton>
       </S.Content>
 
       <S.Grow

--- a/src/components/edit-social-item/styles.ts
+++ b/src/components/edit-social-item/styles.ts
@@ -1,8 +1,6 @@
 import styled, { css } from 'styled-components';
 import { motion, Reorder } from 'framer-motion';
 
-import { Trash, Edit2 } from '@styled-icons/feather';
-
 export const Container = styled(Reorder.Item)`
   ${({ theme }) => css`
     width: 100%;
@@ -82,9 +80,11 @@ export const Name = styled.strong`
   margin-right: auto;
 `;
 
-export const DeleteIcon = styled(Trash)`
+export const DeleteButton = styled.button`
   ${({ theme }) => css`
     cursor: pointer;
+    display: grid;
+    place-items: center;
 
     & * {
       cursor: pointer;
@@ -96,11 +96,13 @@ export const DeleteIcon = styled(Trash)`
   `}
 `;
 
-export const EditIcon = styled(Edit2)`
+export const EditButton = styled.button`
   ${({ theme }) => css`
     grid-area: edit;
     align-self: end;
     justify-self: end;
+    display: grid;
+    place-items: center;
 
     cursor: pointer;
 

--- a/src/components/group-fields/index.tsx
+++ b/src/components/group-fields/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { ChevronRight } from '@styled-icons/feather';
 
 import { inputMap } from 'components';
 import { useCanvas, useSettings } from 'hooks';
@@ -10,6 +9,7 @@ import { checkDeepObjectValue, getDeepObjectProperty } from 'utils';
 
 import { variants } from './animations';
 import * as S from './styles';
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 type Conditions = {
   path: string;
@@ -75,7 +75,7 @@ const GroupFields = ({
               animate={animationState}
               variants={variants.icon}
             >
-              <ChevronRight size={18} />
+              <Icon name="chevron-right" size={18} />
             </S.WrapperIcon>
           )}
 

--- a/src/components/inputs/select/index.tsx
+++ b/src/components/inputs/select/index.tsx
@@ -1,10 +1,10 @@
 import { FocusEvent, useEffect, useRef, useState } from 'react';
-import { X as CloseIcon } from '@styled-icons/feather';
 
 import { useForceUpdate } from 'hooks';
 import { debounce, filterArrayByQueryMatch } from 'utils';
 
 import * as S from './styles';
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 type SelectOption = {
   label: string;
@@ -101,7 +101,7 @@ const Select = ({
       />
 
       <S.Wrapper show={canShowClearButton} onClick={handleSelect()}>
-        <CloseIcon size={20} />
+        <Icon name="x" size={20} />
       </S.Wrapper>
 
       <S.Dropdown

--- a/src/components/modals/base/index.tsx
+++ b/src/components/modals/base/index.tsx
@@ -1,4 +1,5 @@
-import { X as CloseIcon } from '@styled-icons/feather';
+import { Icon } from 'components/ui/primitives/atoms/icon';
+
 import { events } from 'app';
 import * as S from './styles';
 
@@ -14,7 +15,7 @@ const BaseModal = ({ children, title }: BaseModalProps) => {
         {title && <S.Title>{title}</S.Title>}
 
         <S.CloseButton onClick={events.modal.close}>
-          <CloseIcon size={24} />
+          <Icon name="x" size={24} />
         </S.CloseButton>
       </S.Header>
 

--- a/src/components/modals/share/index.tsx
+++ b/src/components/modals/share/index.tsx
@@ -1,4 +1,7 @@
-import { Copy as CopyIcon } from '@styled-icons/feather';
+import { IconName } from 'lucide-react/dynamic';
+
+import { Icon } from 'components/ui/primitives/atoms/icon';
+
 import { config } from 'app';
 
 import { SimpleInput } from 'components';
@@ -23,10 +26,10 @@ const ShareModal = () => {
         </p>
 
         <S.Socials>
-          {socials.map(({ id, icon: Icon, share: Share }) => (
+          {socials.map(({ id, icon, share: Share }) => (
             <S.Social key={id}>
               <Share url={shareUrl}>
-                <Icon size={32} />
+                <Icon name={icon as IconName} size={32} />
               </Share>
             </S.Social>
           ))}
@@ -36,7 +39,7 @@ const ShareModal = () => {
           <SimpleInput defaultValue={shareUrl} disabled />
 
           <S.CopyButton onClick={handleCopyToClipboard}>
-            <CopyIcon size={16} />
+            <Icon name="copy" />
           </S.CopyButton>
         </S.Footer>
       </S.Container>

--- a/src/components/modals/share/socials.ts
+++ b/src/components/modals/share/socials.ts
@@ -1,5 +1,3 @@
-import { Linkedin, Facebook, Twitter } from '@styled-icons/feather';
-
 import {
   FacebookShareButton,
   TwitterShareButton,
@@ -9,17 +7,17 @@ import {
 const socials = [
   {
     id: 1,
-    icon: Linkedin,
+    icon: 'linkedin',
     share: LinkedinShareButton,
   },
   {
     id: 2,
-    icon: Twitter,
+    icon: 'twitter',
     share: TwitterShareButton,
   },
   {
     id: 3,
-    icon: Facebook,
+    icon: 'facebook',
     share: FacebookShareButton,
   },
 ];

--- a/src/components/panels/base/index.tsx
+++ b/src/components/panels/base/index.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronLeft, ChevronRight } from '@styled-icons/feather';
+import { IconName } from 'lucide-react/dynamic';
 
 import { events } from 'app';
 import { PanelsEnumType, PanelSide } from 'types';
+
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 import { useExtensions, useOutsideClick } from 'hooks';
 import { getPanelSideEvent } from 'utils';
@@ -16,8 +18,8 @@ type PanelProps = {
 };
 
 const chevrons = {
-  left: ChevronLeft,
-  right: ChevronRight,
+  left: 'chevron-left',
+  right: 'chevron-right',
 };
 
 const Panel = ({ side, initialPanel }: PanelProps) => {
@@ -59,7 +61,7 @@ const Panel = ({ side, initialPanel }: PanelProps) => {
 
   useOutsideClick(containerRef, () => setIsOpen(false), isOpen);
 
-  const Chevron = chevrons[side];
+  const icon = chevrons[side] as IconName;
 
   return (
     <S.Container ref={containerRef} close={!isOpen}>
@@ -69,7 +71,7 @@ const Panel = ({ side, initialPanel }: PanelProps) => {
         side={side}
         onClick={() => setIsOpen(!isOpen)}
       >
-        <Chevron size={24} />
+        <Icon name={icon} size={24} />
       </S.Toggle>
 
       <S.Wrapper side={side}>

--- a/src/components/panels/new-section/contents.ts
+++ b/src/components/panels/new-section/contents.ts
@@ -1,16 +1,14 @@
-import { FileText, Zap } from '@styled-icons/feather';
-
 import { events } from 'app';
 import { PanelsEnum } from 'types';
 
 const contents = [
   {
-    icon: FileText,
+    icon: 'file-text',
     onClick: () => events.panel.open('right', PanelsEnum.TEMPLATES),
     name: 'Templates',
   },
   {
-    icon: Zap,
+    icon: 'zap',
     onClick: () => events.panel.open('right', PanelsEnum.RECOMMENDED_RESOURCES),
     name: 'Level Up',
   },

--- a/src/components/panels/new-section/index.tsx
+++ b/src/components/panels/new-section/index.tsx
@@ -1,3 +1,7 @@
+import { IconName } from 'lucide-react/dynamic';
+
+import { Icon } from 'components/ui/primitives/atoms/icon';
+
 import { useExtensions } from 'hooks';
 import { PanelsEnum } from 'types';
 
@@ -13,19 +17,19 @@ const PanelNewSection = () => {
 
   return (
     <S.Container>
-      {contents.map(({ icon: Icon, name, ...rest }) => (
+      {contents.map(({ icon, name, ...rest }) => (
         <S.Wrapper key={name} {...rest}>
           <S.Block>
-            <Icon size={48} />
+            <Icon name={icon as IconName} size={48} />
             {name}
           </S.Block>
         </S.Wrapper>
       ))}
 
-      {items.map(({ icon: Icon, name, ...rest }) => (
+      {items.map(({ icon, name, ...rest }) => (
         <S.Wrapper key={name} {...rest}>
           <S.Block>
-            <Icon size={48} />
+            <Icon name={icon as IconName} size={48} />
             {name}
           </S.Block>
         </S.Wrapper>

--- a/src/components/readme-result/actions.ts
+++ b/src/components/readme-result/actions.ts
@@ -1,10 +1,16 @@
-import { Copy } from '@styled-icons/feather';
+import { IconName } from 'lucide-react/dynamic';
 import { copyToClipboard } from 'utils';
 
-const actions = [
+type Action = {
+  label: string;
+  icon: IconName;
+  action: (content: string) => void;
+};
+
+const actions: Action[] = [
   {
     label: 'Copy',
-    icon: Copy,
+    icon: 'copy',
     action: (content: string) => copyToClipboard(content),
   },
 ];

--- a/src/components/readme-result/index.tsx
+++ b/src/components/readme-result/index.tsx
@@ -8,6 +8,7 @@ import { Tooltip } from 'components';
 
 import { actions } from './actions';
 import * as S from './styles';
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 const ReadmeResult = () => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -41,7 +42,7 @@ const ReadmeResult = () => {
   return (
     <S.Container ref={containerRef}>
       <S.Actions>
-        {actions.map(({ icon: Icon, action }, i) => (
+        {actions.map(({ icon, action }, i) => (
           <Tooltip key={i} content={labelVal} position="top">
             <li>
               <S.Action
@@ -50,7 +51,7 @@ const ReadmeResult = () => {
                   handleUpdateLabel();
                 }}
               >
-                <Icon size={16} />
+                <Icon name={icon} />
               </S.Action>
             </li>
           </Tooltip>

--- a/src/components/sections/guard/index.tsx
+++ b/src/components/sections/guard/index.tsx
@@ -5,6 +5,7 @@ import { useCanvas, useSettings } from 'hooks';
 
 import { CanvasStatesEnum } from 'types';
 import * as S from './styles';
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 const BASE_URL = 'https://api.github.com/users/';
 
@@ -69,7 +70,9 @@ const GuardSection = ({ children, sectionId }: GuardSectionProps) => {
         <>{children}</>
       ) : (
         <S.Container onSubmit={handleCheckGithubUsername}>
-          <S.AlertIcon size={24} />
+          <S.AlertWrapper>
+            <Icon name="alert-circle" size={24} />
+          </S.AlertWrapper>
 
           <S.Text>
             To use this section, please tell us your

--- a/src/components/sections/guard/styles.ts
+++ b/src/components/sections/guard/styles.ts
@@ -1,5 +1,4 @@
 import styled, { css } from 'styled-components';
-import { AlertCircle } from '@styled-icons/feather';
 
 import { SimpleInput } from 'components/inputs';
 
@@ -14,10 +13,12 @@ export const Container = styled.form`
   `}
 `;
 
-export const AlertIcon = styled(AlertCircle)`
+export const AlertWrapper = styled.div`
   ${({ theme }) => css`
     color: ${theme.colors.tertiary};
     grid-area: icon;
+    display: grid;
+    place-items: center;
   `}
 `;
 

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,12 +1,14 @@
 import { AnimatePresence } from 'framer-motion';
-import { StyledIcon } from '@styled-icons/styled-icon';
+import { IconName } from 'lucide-react/dynamic';
 
-import * as S from './styles';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 
+import { Icon } from 'components/ui/primitives/atoms/icon';
+import * as S from './styles';
+
 type Tab = {
-  icon?: StyledIcon;
+  icon?: IconName;
   label: string;
   view: string;
 };
@@ -38,7 +40,7 @@ const Tabs = ({
     <S.Container>
       <AnimatePresence>
         <S.Tabs>
-          {tabs.map(({ label, icon: Icon, view }) => {
+          {tabs.map(({ label, icon, view }) => {
             const active = view === currentTab;
 
             return (
@@ -48,7 +50,7 @@ const Tabs = ({
                 onClick={() => setCurrentTab(view)}
               >
                 <S.Wrapper>
-                  {Icon && <Icon size={20} />}
+                  {icon && <Icon name={icon} size={20} />}
 
                   <S.Label>{label}</S.Label>
                 </S.Wrapper>

--- a/src/components/tech-icon-variants/index.tsx
+++ b/src/components/tech-icon-variants/index.tsx
@@ -1,7 +1,8 @@
 import { useState, useImperativeHandle, forwardRef, useEffect } from 'react';
 
 import { useDragControls, usePresence } from 'framer-motion';
-import { Menu } from '@styled-icons/feather';
+
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 import { events } from 'app';
 
@@ -95,7 +96,7 @@ const TechIconVariants: React.ForwardRefRenderFunction<
             dragControls.start(event),
           ]}
         >
-          <Menu />
+          <Icon name="menu" size={20} />
         </S.Drag>
 
         <S.Logo
@@ -107,7 +108,9 @@ const TechIconVariants: React.ForwardRefRenderFunction<
         <S.Wrapper>
           <S.Name>{shortname || name}</S.Name>
 
-          <S.DeleteIcon size={16} onClick={handleDeleteTech} />
+          <S.DeleteButton onClick={handleDeleteTech}>
+            <Icon name="trash" />
+          </S.DeleteButton>
         </S.Wrapper>
 
         <Providers
@@ -116,7 +119,11 @@ const TechIconVariants: React.ForwardRefRenderFunction<
           available={available_providers}
         />
 
-        {hasVariants && <S.EditIcon size={16} onClick={handleToggleEditForm} />}
+        {hasVariants && (
+          <S.EditButton onClick={handleToggleEditForm}>
+            <Icon name="edit-2" />
+          </S.EditButton>
+        )}
       </S.Content>
 
       <S.Grow

--- a/src/components/tech-icon-variants/styles.ts
+++ b/src/components/tech-icon-variants/styles.ts
@@ -1,8 +1,6 @@
 import styled, { css } from 'styled-components';
 import { motion, Reorder } from 'framer-motion';
 
-import { Edit2, Trash } from '@styled-icons/feather';
-
 export const Container = styled(Reorder.Item)`
   ${({ theme }) => css`
     width: 100%;
@@ -82,9 +80,11 @@ export const Name = styled.strong`
   margin-right: auto;
 `;
 
-export const DeleteIcon = styled(Trash)`
+export const DeleteButton = styled.button`
   ${({ theme }) => css`
     cursor: pointer;
+    display: grid;
+    place-items: center;
 
     & * {
       cursor: pointer;
@@ -96,11 +96,13 @@ export const DeleteIcon = styled(Trash)`
   `}
 `;
 
-export const EditIcon = styled(Edit2)`
+export const EditButton = styled.button`
   ${({ theme }) => css`
     grid-area: edit;
     align-self: end;
     justify-self: end;
+    display: grid;
+    place-items: center;
 
     cursor: pointer;
 

--- a/src/components/tree/file/index.tsx
+++ b/src/components/tree/file/index.tsx
@@ -1,4 +1,5 @@
-import { File as FileIcon } from '@styled-icons/feather';
+import { Icon } from 'components/ui/primitives/atoms/icon';
+
 import { events } from 'app';
 
 import { File as FileType } from '..';
@@ -11,7 +12,7 @@ const File = ({ file, content }: FileProps) => {
 
   return (
     <S.Container onClick={handleClick}>
-      <FileIcon />
+      <Icon name="file" size={20} />
       {file}
     </S.Container>
   );

--- a/src/components/tree/folder/index.tsx
+++ b/src/components/tree/folder/index.tsx
@@ -1,4 +1,4 @@
-import { Folder as FolderIcon } from '@styled-icons/feather';
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 import { File } from '../file';
 import { Label } from '../label';
@@ -14,7 +14,7 @@ const Folder = ({ name, files }: FolderProps) => {
   return hasFiles ? (
     <S.Container>
       <Label>
-        <FolderIcon />
+        <Icon name="folder" size={20} />
         {name}
       </Label>
 

--- a/src/components/ui/primitives/atoms/icon.tsx
+++ b/src/components/ui/primitives/atoms/icon.tsx
@@ -1,0 +1,12 @@
+import { DynamicIcon } from 'lucide-react/dynamic';
+import React from 'react';
+
+type IconsProps = Partial<React.ComponentPropsWithoutRef<typeof DynamicIcon>>;
+
+export function Icon(props: IconsProps) {
+  const { name = 'github', size = 16, strokeWidth = 1, ...rest } = props;
+
+  return (
+    <DynamicIcon name={name} size={size} strokeWidth={strokeWidth} {...rest} />
+  );
+}

--- a/src/features/activities/index.ts
+++ b/src/features/activities/index.ts
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic';
-import { Star } from '@styled-icons/feather';
 
 import { activitiesSectionParser } from './parser';
 import { defaultActivitiesSectionConfig } from './default-config';
@@ -12,7 +11,7 @@ const feature = {
 
   presentation: {
     [PanelsEnum.NEW_SECTION]: {
-      icon: Star,
+      icon: 'activity',
       onClick: () => events.canvas.add(Sections.ACTIVITIES),
       name: 'My activities',
     },

--- a/src/features/image/index.ts
+++ b/src/features/image/index.ts
@@ -1,7 +1,5 @@
 import dynamic from 'next/dynamic';
 
-import { Image } from '@styled-icons/feather';
-
 import { imageSectionParser } from './parser';
 import { defaultImageSectionConfig } from './default-config';
 
@@ -13,7 +11,7 @@ const feature = {
 
   presentation: {
     [PanelsEnum.NEW_SECTION]: {
-      icon: Image,
+      icon: 'image',
       onClick: () => events.canvas.add(Sections.IMAGE),
       name: 'Image',
     },

--- a/src/features/music/index.ts
+++ b/src/features/music/index.ts
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic';
-import { Music } from '@styled-icons/feather';
 
 import { musicSectionParser } from './parser';
 import { defaultMusicSectionConfig } from './default-config';
@@ -12,7 +11,7 @@ const feature = {
 
   presentation: {
     [PanelsEnum.NEW_SECTION]: {
-      icon: Music,
+      icon: 'music',
       onClick: () => events.canvas.add(Sections.MUSIC),
       name: 'Music',
     },

--- a/src/features/pacman/index.ts
+++ b/src/features/pacman/index.ts
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic';
-import { Gitlab } from '@styled-icons/feather';
 
 import { pacmanSectionParser, pacmanWorkflowParser } from './parser';
 import { defaultPacmanSectionConfig } from './default-config';
@@ -12,7 +11,7 @@ const feature = {
 
   presentation: {
     [PanelsEnum.NEW_SECTION]: {
-      icon: Gitlab,
+      icon: 'ghost',
       onClick: () => events.canvas.add(Sections.PACMAN),
       name: 'Pacman',
     },

--- a/src/features/profile-views/index.ts
+++ b/src/features/profile-views/index.ts
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic';
-import { Github } from '@styled-icons/feather';
 
 import { profileViewsSectionParser } from './parser';
 import { defaultProfileViewsSectionConfig } from './default-config';
@@ -12,7 +11,7 @@ const feature = {
 
   presentation: {
     [PanelsEnum.NEW_SECTION]: {
-      icon: Github,
+      icon: 'telescope',
       onClick: () => events.canvas.add(Sections.PROFILE_VIEWS),
       name: 'Profile views',
     },

--- a/src/features/snake/index.ts
+++ b/src/features/snake/index.ts
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic';
-import { Activity } from '@styled-icons/feather';
 
 import { snakeSectionParser, snakeWorkflowParser } from './parser';
 import { defaultSnakeSectionConfig } from './default-config';
@@ -12,7 +11,7 @@ const feature = {
 
   presentation: {
     [PanelsEnum.NEW_SECTION]: {
-      icon: Activity,
+      icon: 'worm',
       onClick: () => events.canvas.add(Sections.SNAKE),
       name: 'Snake',
     },

--- a/src/features/socials/index.ts
+++ b/src/features/socials/index.ts
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic';
-import { MessageSquare } from '@styled-icons/feather';
 
 import { socialsSectionParser } from './parser';
 import { defaultSocialsSectionConfig } from './default-config';
@@ -12,7 +11,7 @@ const feature = {
 
   presentation: {
     [PanelsEnum.NEW_SECTION]: {
-      icon: MessageSquare,
+      icon: 'message-square',
       onClick: () => events.canvas.add(Sections.SOCIALS),
       name: 'Social Media',
     },

--- a/src/features/socials/panel/tabs.ts
+++ b/src/features/socials/panel/tabs.ts
@@ -1,10 +1,8 @@
-import { StyledIcon } from '@styled-icons/styled-icon';
-import { Plus, Edit2 } from '@styled-icons/feather';
-
 import { views } from './views';
+import { IconName } from 'lucide-react/dynamic';
 
 type Tab = {
-  icon: StyledIcon;
+  icon: IconName;
   label: string;
   view: keyof typeof views;
 };
@@ -12,12 +10,12 @@ type Tab = {
 const tabs: Tab[] = [
   {
     label: 'Add',
-    icon: Plus,
+    icon: 'plus',
     view: 'adding',
   },
   {
     label: 'Edit',
-    icon: Edit2,
+    icon: 'edit-2',
     view: 'editing',
   },
 ];

--- a/src/features/stats/index.ts
+++ b/src/features/stats/index.ts
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic';
-import { PieChart } from '@styled-icons/feather';
 
 import { statsSectionParser } from './parser';
 import { defaultStatsSectionConfig } from './default-config';
@@ -12,7 +11,7 @@ const feature = {
 
   presentation: {
     [PanelsEnum.NEW_SECTION]: {
-      icon: PieChart,
+      icon: 'pie-chart',
       onClick: () => events.canvas.add(Sections.STATS),
       name: 'Stats',
     },

--- a/src/features/stats/panel/tabs.ts
+++ b/src/features/stats/panel/tabs.ts
@@ -1,10 +1,8 @@
-import { StyledIcon } from '@styled-icons/styled-icon';
-import { Layout, Settings } from '@styled-icons/feather';
-
 import { views } from './views';
+import { IconName } from 'lucide-react/dynamic';
 
 type Tab = {
-  icon: StyledIcon;
+  icon: IconName;
   label: string;
   view: keyof typeof views;
 };
@@ -12,12 +10,12 @@ type Tab = {
 const tabs: Tab[] = [
   {
     label: 'Layout',
-    icon: Layout,
+    icon: 'layout',
     view: 'layout',
   },
   {
     label: 'Config Stats',
-    icon: Settings,
+    icon: 'settings',
     view: 'config',
   },
 ];

--- a/src/features/stats/panel/views/layout/item/index.tsx
+++ b/src/features/stats/panel/views/layout/item/index.tsx
@@ -1,8 +1,9 @@
 import { useDragControls } from 'framer-motion';
-import { Menu, Eye, EyeOff, Settings } from '@styled-icons/feather';
 
 import Router from 'next/router';
+
 import { Tooltip } from 'components';
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 import { variants, animations } from './animations';
 import { events } from 'app';
@@ -44,7 +45,7 @@ const Item = ({ stats, isShowing }: EditSocialItemProps) => {
   };
 
   const label = isShowing ? 'Hide' : 'Show';
-  const Icon = isShowing ? Eye : EyeOff;
+  const eyeIcon = isShowing ? 'eye' : 'eye-off';
 
   return (
     <S.Container
@@ -57,7 +58,7 @@ const Item = ({ stats, isShowing }: EditSocialItemProps) => {
     >
       <S.Content>
         <S.Drag onPointerDown={event => [dragControls.start(event)]}>
-          <Menu />
+          <Icon name="menu" size={20} />
         </S.Drag>
 
         <S.Wrapper>
@@ -67,13 +68,13 @@ const Item = ({ stats, isShowing }: EditSocialItemProps) => {
         <S.Actions>
           <Tooltip content={label} position="right" variant="info">
             <S.Button onClick={handleChangeDisplay}>
-              <Icon size={16} />
+              <Icon name={eyeIcon} />
             </S.Button>
           </Tooltip>
 
           <Tooltip content="Configure" position="right" variant="info">
             <S.Button onClick={handleConfigure}>
-              <Settings size={16} />
+              <Icon name="settings" />
             </S.Button>
           </Tooltip>
         </S.Actions>

--- a/src/features/techs/index.ts
+++ b/src/features/techs/index.ts
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic';
-import { Share2 } from '@styled-icons/feather';
+
+import { Icon } from 'components/ui/primitives/atoms/icon';
 
 import { techsSectionParser } from './parser';
 import { defaultTechsSectionConfig } from './default-config';
@@ -12,7 +13,7 @@ const feature = {
 
   presentation: {
     [PanelsEnum.NEW_SECTION]: {
-      icon: Share2,
+      icon: 'cpu',
       onClick: () => events.canvas.add(Sections.TECHS),
       name: 'Techs',
     },

--- a/src/features/techs/panel/tabs.ts
+++ b/src/features/techs/panel/tabs.ts
@@ -1,10 +1,8 @@
-import { StyledIcon } from '@styled-icons/styled-icon';
-import { Plus, Edit2 } from '@styled-icons/feather';
-
 import { views } from './views';
+import { IconName } from 'lucide-react/dynamic';
 
 type Tab = {
-  icon: StyledIcon;
+  icon: IconName;
   label: string;
   view: keyof typeof views;
 };
@@ -12,12 +10,12 @@ type Tab = {
 const tabs: Tab[] = [
   {
     label: 'Add',
-    icon: Plus,
+    icon: 'plus',
     view: 'adding',
   },
   {
     label: 'Edit',
-    icon: Edit2,
+    icon: 'edit-2',
     view: 'editing',
   },
 ];

--- a/src/features/text/index.ts
+++ b/src/features/text/index.ts
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic';
-import { Type } from '@styled-icons/feather';
 
 import { textSectionParser } from './parser';
 import { defaultTextSectionConfig } from './default-config';
@@ -12,7 +11,7 @@ const feature = {
 
   presentation: {
     [PanelsEnum.NEW_SECTION]: {
-      icon: Type,
+      icon: 'type',
       onClick: () => events.canvas.add(Sections.TEXT),
       name: 'Text',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,7 +867,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.20.7":
+"@babel/runtime@^7.11.2":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.1.tgz#9fce313d12c9a77507f264de74626e87fd0dc541"
   integrity sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==
@@ -1534,21 +1534,6 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
-
-"@styled-icons/feather@^10.47.0":
-  version "10.47.0"
-  resolved "https://registry.yarnpkg.com/@styled-icons/feather/-/feather-10.47.0.tgz#20e1bbc38e12a99fbda3889a8d1d025b3a8ce76f"
-  integrity sha512-w6F3s1B4DaQGLr4AZZ0PffZQOnPSRqr3npHoTvk4Juz4uTjw9/oHolcrTxPyJas9gXAV1kCLbeiaxTR6JVxJPw==
-  dependencies:
-    "@babel/runtime" "^7.20.7"
-    "@styled-icons/styled-icon" "^10.7.0"
-
-"@styled-icons/styled-icon@^10.7.0":
-  version "10.7.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/styled-icon/-/styled-icon-10.7.1.tgz#da04b80751e126756f98a5485b3b0dd9b52c9aba"
-  integrity sha512-WLYaeMTMhMkSxE+v+of+r2ovIk0tceDGfv8iqWHRMxvbm+6zxngVcQ4ELx6Zt/LFxqckmmoAdvo6ehiiYj6I6A==
-  dependencies:
-    "@babel/runtime" "^7.20.7"
 
 "@surma/rollup-plugin-off-main-thread@^2.2.3":
   version "2.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4653,6 +4653,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lucide-react@^0.511.0:
+  version "0.511.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.511.0.tgz#1dfef3065c725ac83f5fe0a6f02d1e0b0c36e641"
+  integrity sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==
+
 magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did

I replaced @styled-icons/feather icons with Lucid Icons lib

<!--
  A clear and concise description of what you did. If applicable, add screenshots/gifs to show your UI changes
 -->
