### PR TITLE
🐛 fix: socials input box unfocusing on input

### DIFF
--- a/src/features/socials/panel/views/editing/index.tsx
+++ b/src/features/socials/panel/views/editing/index.tsx
@@ -28,7 +28,7 @@ interface MemoizedIconEditorProps {
   social: string;
   props: Social;
   index: number;
-  iconEditorRefs: React.MutableRefObject<IconEditorRef[]>;
+  iconEditorRefs: React.RefObject<IconEditorRef[]>;
 }
 
 const MemoizedIconEditor = React.memo(
@@ -67,11 +67,12 @@ const MemoizedIconEditor = React.memo(
     );
   },
   (prevProps: MemoizedIconEditorProps, nextProps: MemoizedIconEditorProps) => {
-    if (prevProps.social !== nextProps.social) return false;
-    if (prevProps.index !== nextProps.index) return false;
-    if (prevProps.props.icon !== nextProps.props.icon) return false;
-    if (prevProps.props.short_name !== nextProps.props.short_name) return false;
-    return true;
+    return (
+      prevProps.social === nextProps.social &&
+      prevProps.props.icon === nextProps.props.icon &&
+      prevProps.props.short_name === nextProps.props.short_name &&
+      prevProps.index === nextProps.index
+    );
   }
 );
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did

Hello, again!👋

I added memoization for the `IconEditor` component in the socials `Editing` panel so that it doesn't unnecessarily rebuild each time the input/value is changed of an icon's URL.

This fixes the issue where each time you type in one of the boxes, the UI rebuilds which then unfocuses the input box.

I also added memoization for the `socials` and `socials_names` so that they don't get updated when the event is triggered too, unless the length of the socials has changed, e.g. when a social is added/deleted.

This works on my local machine, but it would be great if someone could verify it actually fixes the issue on theirs too! 

Please let me know if there are any issues! 😊

## Commit description

The event CANVAS_EDIT_SECTION gets called every time the value of the social input box gets changed to update the UI, which updates the currently selected secton, which in turn updates the editor panel, causing the input boxes to unnecessarily refresh, thus unfocusing. Memoizing fixes these unnecessary rebuilds.

Fixes #139