### PR TITLE
fix(parseToReadme): add default empty object for styles prop

### DIFF
--- a/src/utils/parseToReadme/index.ts
+++ b/src/utils/parseToReadme/index.ts
@@ -9,7 +9,7 @@ const parseToReadme = (
   settings: Settings
 ) => {
   const readme = template.reduce((readme, section) => {
-    const { state, styles } = section.props;
+    const { state, styles = {} } = section.props;
 
     if (state === CanvasStatesEnum.ALERT) return readme;
 


### PR DESCRIPTION
Prevent potential runtime errors when section.props.styles is undefined by providing a default empty object

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ *] Refactor
- [ *] Feature
- [ *] Bug Fix
- [ *] Enhancement
- [ ] Documentation Update

## What I did

Fixed a `TypeError: Cannot read properties of undefined (reading 'clear')` that occurred when clicking "Generate README" in the application.

### Problem
The error occurred in `src/utils/parseToReadme/index.ts` at line 22, where the code attempted to access the `clear `property of an undefined `styles `object. This occurred because some canvas sections don't have a `styles` property in their `props` , causing the destructuring assignment to fail when trying to access `styles.clear` .

Added a default empty object` {}` to the destructuring assignment for the `styles `property: 
```
// Before (causing TypeError)
const { state, styles } = section.props;

// After (safe with default value)
const { state, styles = {} } = section.props;
```

### Impact
- ✅ Eliminates the runtime TypeError when generating README
- ✅ Maintains existing functionality - the ternary condition `styles.clear ? '\n<br clear="both">\n'` : '' continues to work correctly
- ✅ Follows TypeScript best practices for handling potentially undefined properties
- ✅ Minimal, non-breaking change that doesn't affect other parts of the codebase


### Testing
- Verified the fix resolves the TypeError when clicking "Generate README"
- Confirmed existing functionality remains intact
- No breaking changes to the README generation process
This is a critical bug fix that prevents the application from crashing during the core README generation functionality.