### PR TITLE
fix: handle undefined parsers in parseToReadme function

### DIFF
--- a/src/utils/parseToReadme/index.ts
+++ b/src/utils/parseToReadme/index.ts
@@ -5,9 +5,11 @@ import { CanvasSection, CanvasStatesEnum, Settings } from 'types';
 
 const parseToReadme = (
   template: CanvasSection[],
-  parsers: Record<string, any>,
+  parsers: Record<string, any> | undefined,
   settings: Settings
 ) => {
+  if (!parsers) parsers = {} as Record<string, any>;
+
   const readme = template.reduce((readme, section) => {
     const { state, styles = {} } = section.props;
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Enhancement
- [ ] Documentation Update

## What I did
Added early validation for `parsers` parameter
