### PR TITLE
🐛 fix: stats urls

### DIFF
--- a/src/config/general/index.ts
+++ b/src/config/general/index.ts
@@ -15,11 +15,13 @@ const general = {
       },
 
       stats: {
-        imageBaseUrl: 'https://github-readme-stats.vercel.app/api',
+        imageBaseUrl:
+          'https://github-readme-stats.profile-readme-generator.com/api',
         streakBaseUrl: 'https://streak-stats.demolab.com',
-        trophiBaseUrl: 'https://github-profile-trophy.vercel.app',
+        trophiBaseUrl:
+          'https://github-profile-trophy.profile-readme-generator.com',
         activityGraphBaseUrl:
-          'https://github-readme-activity-graph.vercel.app/graph',
+          'https://github-readme-activity-graph.profile-readme-generator.com/graph',
       },
 
       borders: {

--- a/src/config/general/index.ts
+++ b/src/config/general/index.ts
@@ -18,7 +18,7 @@ const general = {
         imageBaseUrl:
           'https://github-readme-stats.profile-readme-generator.com/api',
         streakBaseUrl: 'https://streak-stats.demolab.com',
-        trophiBaseUrl:
+        trophyBaseUrl:
           'https://github-profile-trophy.profile-readme-generator.com',
         activityGraphBaseUrl:
           'https://github-readme-activity-graph.profile-readme-generator.com/graph',

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,5 +1,4 @@
 import { Events } from 'types';
-
 import { Handles } from './handles';
 
 type Callback = (args: any) => void;

--- a/src/utils/getStatsUrl/index.ts
+++ b/src/utils/getStatsUrl/index.ts
@@ -1,13 +1,13 @@
 import { config } from 'config';
 
-const { imageBaseUrl, streakBaseUrl, trophiBaseUrl, activityGraphBaseUrl } =
+const { imageBaseUrl, streakBaseUrl, trophyBaseUrl, activityGraphBaseUrl } =
   config.general.urls.sections.stats;
 
 const urls = (value: string) => ({
   stats: `${imageBaseUrl}?username=${value}`,
   languages: `${imageBaseUrl}/top-langs?username=${value}`,
   streak: `${streakBaseUrl}?user=${value}`,
-  trophy: `${trophiBaseUrl}?username=${value}`,
+  trophy: `${trophyBaseUrl}?username=${value}`,
   'activity-graph': `${activityGraphBaseUrl}?username=${value}`,
 });
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
 
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
 
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->
 
## What type of PR is this? (check all applicable)
 
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update
 
## What I did
 
Replaced outdated stats URLs with self-hosted instances. The previous URLs were experiencing frequent downtime and overload issues, causing the stats cards to be unavailable for users.
 
### Changes
 
- **Bug Fix**: Updated stats URLs to use self-hosted instances for improved reliability
 
This change ensures that stats cards remain consistently available by using more reliable URL endpoints.