### PR TITLE
fix: add default theme class to html element for SSR compatibility

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,7 @@ import Document, { Html, Head, Main, NextScript } from 'next/document';
 export default class MyDocument extends Document {
   render(): import('react/jsx-runtime').JSX.Element {
     return (
-      <Html>
+      <Html className="theme-dark">
         <Head />
         <body className="tone palette-brand base-1">
           <Main />


### PR DESCRIPTION
## Problem

When the page is server-side rendered (SSR), the `<html>` element does not have a `theme-dark` or `theme-light` class. The `ThemeHandler` component applies the theme class via `useEffect`, which only runs on the client side.

Without a theme class, CSS variables like `--background-default` and `--foreground` are undefined (defined under `.theme-dark .base-1` / `.theme-light .base-1` selectors). This results in:

- No background color on the page
- No text color on the page
- A black/blank screen until JavaScript finishes executing
- Complete white screen in SSR-only or no-JS environments

## Root Cause

The CSS theme tokens are scoped under `.theme-dark` and `.theme-light`:

```css
/* src/styles/themes/dark.css */
.theme-dark .base-1 {
  --background-default: 216 28% 7%;
  --foreground: 210 17% 82%;
  --ring-inner: 212 12% 21%;
}
```

The `ThemeHandler` component in `src/components/global-handlers/theme.tsx` applies the class on the client side:

```tsx
// useEffect runs only on the client
useEffect(() => {
  changeTheme(getCurrentTheme());
  // ...
}, []);
```

During SSR, `<html>` has no theme class, so the selector `.theme-dark .base-1` does not match `<body class="tone palette-brand base-1">`. All CSS variables are `undefined` — the page renders with no background and no text color.

## Solution

Add `className="theme-dark"` to the `<Html>` element in `_document.tsx`:

```diff
 import Document, { Html, Head, Main, NextScript } from 'next/document';

 export default class MyDocument extends Document {
   render(): import('react/jsx-runtime').JSX.Element {
     return (
-      <Html>
+      <Html className="theme-dark">
         <Head />
         <body className="tone palette-brand base-1">
           <Main />
           <NextScript />
         </body>
       </Html>
     );
   }
 }
```

This ensures CSS variables are defined during SSR. Once the client-side JavaScript loads, `ThemeHandler` will detect the user's actual preference and apply the correct `theme-light` or `theme-dark` class, overriding the default.

## Notes

- `ThemeHandler.getSystemTheme()` already returns `'dark'` as the SSR fallback, so this change is consistent with the existing default logic
- The flash from dark → light theme (if the user prefers light) is a minor trade-off compared to the complete blank screen during SSR
