### PR TITLE
fix: omit default trophy columns from workflow

### DIFF
--- a/src/features/stats/parser/trophy-workflow.ts
+++ b/src/features/stats/parser/trophy-workflow.ts
@@ -22,6 +22,7 @@ const buildTrophyWithBlock = (props: Obj) => {
       const value = props[panelKey];
 
       if (value === undefined || value === null || value === '') return lines;
+      if (panelKey === 'column' && Number(value) === -1) return lines;
 
       const line = `${indent}${actionKey}: ${String(value)}`;
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

  - [ ] Refactor
  - [ ] Feature
  - [x] Bug Fix
  - [ ] Enhancement
  - [ ] Documentation Update

## What I did

Fixes https://github.com/maurodesouza/profile-readme-generator/issues/193

This PR prevents the generated trophy workflow from emitting `max-cols: -1` when the Trophy column value is the default adaptive value.

The generated workflow previously included:

```yaml
max-cols: -1
```

That caused Erik-Donath/github-profile-trophy@feature/generate-svg to fail with:

```
Invalid cols: ""; Must be a number!
```

The trophy action already defaults to adaptive columns internally, so omitting max-cols for column: -1 preserves the same behavior while avoiding the workflow failure.

Positive column values are still emitted normally. For example, if a user sets the Trophy column value to 8, the generated workflow will still include:
```
max-cols: 8
```

Verification:

- Reproduced the issue with a generated profile workflow that included max-cols: -1.
- Confirmed the workflow succeeds after removing max-cols: -1, while keeping max-rows, margins, theme, background, and frame options unchanged.
- Locally verified the workflow parser behavior:
  - when Trophy column is -1, the generated workflow omits max-cols;
  - when Trophy column is a positive value such as 8, the generated workflow still includes max-cols: 8.
- Ran yarn lint; it completed with 0 errors and existing warnings only.
