### PR TITLE
fix: resolve canvas section text editing locked state and add copy to…

### DIFF
--- a/src/contexts/canvas.tsx
+++ b/src/contexts/canvas.tsx
@@ -68,9 +68,11 @@ const CanvasProvider = ({ children }: CanvasProviderProps) => {
 
     const obj = sections.find(item => item.id === id)!;
 
+    const finalPath = path.startsWith('props.') ? path : `props.${path}`;
+
     const result = deepChangeObjectProperty<CanvasSection>({
       obj,
-      path,
+      path: finalPath,
       value,
     });
 

--- a/src/utils/copyToClipboard/index.ts
+++ b/src/utils/copyToClipboard/index.ts
@@ -1,5 +1,36 @@
 const copyToClipboard = async (string: string) => {
-  await navigator.clipboard.writeText(string);
+  if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+    await navigator.clipboard.writeText(string);
+  } else {
+    const textArea = document.createElement('textarea');
+    textArea.value = string;
+    textArea.style.position = 'fixed';
+    textArea.style.top = '0';
+    textArea.style.left = '0';
+    textArea.style.width = '2em';
+    textArea.style.height = '2em';
+    textArea.style.padding = '0';
+    textArea.style.border = 'none';
+    textArea.style.outline = 'none';
+    textArea.style.boxShadow = 'none';
+    textArea.style.background = 'transparent';
+    
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    
+    try {
+      const successful = document.execCommand('copy');
+      if (!successful) {
+        throw new Error('execCommand copy was unsuccessful');
+      }
+    } catch (err) {
+      console.error('Fallback copy failed', err);
+      throw err;
+    } finally {
+      document.body.removeChild(textArea);
+    }
+  }
 };
 
 export { copyToClipboard };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did

This PR fixes two major client-side issues to restore correct text editing and clipboard copying functionality:

1. **Fixed Locked/Unresponsive Form Inputs in Sidebar (Canvas Edit Path bug):**
   * **Issue:** Editing values (like the `Text` textarea) was unresponsive because state updates in `handleEditSection` (located in [canvas.tsx](file:///c:/Users/joaov/profile-readme-generator/src/contexts/canvas.tsx#L58-L89)) were targeting root-level keys of the section objects instead of nested `props` keys.
   * **Solution:** Adjusted `handleEditSection` to automatically prepend the `'props.'` prefix to the state update paths if it is not already present, ensuring properties like `props.content.text`, `props.state`, and `props.styles` are updated properly.

2. **Added Clipboard Copy Fallback for Non-Secure Contexts:**
   * **Issue:** In environments where `navigator.clipboard` is not available (e.g., non-secure `HTTP` connections, net blocks, or older browsers), attempting to copy the generated README threw a `TypeError: Cannot read properties of undefined (reading 'writeText')`.
   * **Solution:** Added a robust fallback in [copyToClipboard](file:///c:/Users/joaov/profile-readme-generator/src/utils/copyToClipboard/index.ts) that uses a temporary hidden `<textarea>` and `document.execCommand('copy')` to copy text successfully in any browser environment.
