### PR TITLE
✨ feat: add workflow files highlight feature with visual feedback

### DIFF
--- a/src/components/atoms/tree/index.tsx
+++ b/src/components/atoms/tree/index.tsx
@@ -10,10 +10,12 @@ import { actions } from 'lib/command';
 export type TFile = {
   file: string;
   content: string;
+  className?: string;
 };
 
 export type TFolder = {
   name?: string;
+  className?: string;
   files: TFile[];
 };
 
@@ -36,7 +38,7 @@ function Label(props: LabelProps) {
 type FileProps = TFile;
 
 function File(props: FileProps) {
-  const { content, file } = props;
+  const { content, file, className } = props;
 
   function onClick() {
     actions.result.show(content);
@@ -44,7 +46,7 @@ function File(props: FileProps) {
 
   return (
     <button className="flex w-full mt-xs **:cursor-pointer hover:text-tone-foreground-context!">
-      <Label onClick={onClick} icon="file">
+      <Label onClick={onClick} icon="file" className={className}>
         {file}
       </Label>
     </button>
@@ -54,13 +56,15 @@ function File(props: FileProps) {
 type FolderProps = TFolder;
 
 function Folder(props: FolderProps) {
-  const { name, files } = props;
+  const { name, files, className } = props;
 
   const hasFiles = !!files.length;
 
   return hasFiles ? (
     <div>
-      <Label icon="folder">{name}</Label>
+      <Label icon="folder" className={className}>
+        {name}
+      </Label>
 
       <div className="ml-md">
         {files.map(file => (

--- a/src/components/organisms/panels/generated-files/index.tsx
+++ b/src/components/organisms/panels/generated-files/index.tsx
@@ -1,22 +1,68 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Tree } from '#/components/atoms/tree';
+import { TFile, TFolder } from '#/components/atoms/tree';
 
-import { actions } from 'lib/command';
+import { actions, command } from 'lib/command';
 import { parseToReadme } from 'utils';
 import { useCanvas, useExtensions, useSettings } from 'hooks';
 
+const WORKFLOWS_FOLDER = '.github/workflows';
+const WORKFLOWS_CLASS = 'tone palette-warning text-tone-foreground-context';
+
 const PanelGeneratedFiles = () => {
+  const [isHighlighted, setIsHighlighted] = useState(false);
+
   const { sections } = useCanvas();
   const { settings } = useSettings();
   const { extensions } = useExtensions();
 
-  const tree = parseToReadme(sections, extensions.sections, settings);
+  const generatedTree = useMemo(
+    () => parseToReadme(sections, extensions.sections, settings),
+    [sections, extensions.sections, settings]
+  );
+
+  const tree = useMemo((): TFolder[] => {
+    if (!isHighlighted) return generatedTree;
+
+    return generatedTree.map((folder): TFolder => {
+      if (folder.name !== WORKFLOWS_FOLDER) return folder;
+
+      const highlightedFiles = folder.files.map(
+        (file): TFile => ({
+          ...file,
+          className: WORKFLOWS_CLASS,
+        })
+      );
+
+      return {
+        ...folder,
+        className: WORKFLOWS_CLASS,
+        files: highlightedFiles,
+      };
+    });
+  }, [isHighlighted]);
 
   useEffect(() => {
     const content = tree[1].files[0].content;
 
     window.setTimeout(() => actions.result.show(content), 0);
+  }, []);
+
+  useEffect(() => {
+    const disposeHighlight = command.handle(
+      'generated.workflows.highlight',
+      () => setIsHighlighted(true)
+    );
+    const disposeUnhighlight = command.handle(
+      'generated.workflows.unhighlight',
+      () => setIsHighlighted(false)
+    );
+
+    return () => {
+      disposeHighlight();
+      disposeUnhighlight();
+    };
   }, []);
 
   return (

--- a/src/components/templates/result/index.tsx
+++ b/src/components/templates/result/index.tsx
@@ -11,11 +11,21 @@ import { ReadmeResult } from '#/components/organisms/readme-result';
 import { PageFooter } from '#/components/molecules/page-footer';
 import { CopyToClipboard } from '#/components/molecules/copy-to-clipboard';
 
-import { command } from 'lib/command';
+import { actions, command } from 'lib/command';
 import { PanelsEnum } from 'types';
+
+import { useCanvas, useExtensions, useSettings } from 'hooks';
+import { parseToReadme } from 'utils';
 
 export function ResultTemplate() {
   const [content, setContent] = useState('');
+
+  const { sections } = useCanvas();
+  const { extensions } = useExtensions();
+  const { settings } = useSettings();
+
+  const hasWorkflows =
+    parseToReadme(sections, extensions.sections, settings)[0].files.length > 0;
 
   function handleShowContent(content: string) {
     setContent(content);
@@ -72,6 +82,23 @@ export function ResultTemplate() {
           <ReadmeResult content={content} />
         </Page.Content>
 
+        {hasWorkflows && (
+          <Text.Paragraph
+            className="text-center"
+            onMouseEnter={() => actions.generated.workflows.highlight()}
+            onMouseLeave={() => actions.generated.workflows.unhighlight()}
+          >
+            Hey, hey, hey! You also generated workflow files in{' '}
+            <Text.Highlight className="tone palette-warning self-center">
+              .github/workflows
+            </Text.Highlight>
+            &nbsp;.
+            <br />
+            Don&apos;t forget to copy those too — your README won&apos;t work
+            without them!
+          </Text.Paragraph>
+        )}
+
         <PageFooter.Container>
           <PageFooter.Owner />
           <PageFooter.Navs />
@@ -82,7 +109,7 @@ export function ResultTemplate() {
                 <Clickable.Button
                   onClick={copy}
                   tone="success"
-                  className="w-[166px]"
+                  className="w-41.5"
                 >
                   <Icon name={isCopied ? 'check' : 'copy'} />
                   {isCopied ? 'Copied 🎉' : 'Copy File Content'}

--- a/src/lib/command/global.ts
+++ b/src/lib/command/global.ts
@@ -2,7 +2,6 @@ import type {
   CanvasSection,
   Extension,
   PanelsEnumType,
-  PanelSide,
   Renderable,
   Sections,
 } from 'types';
@@ -46,6 +45,13 @@ export interface Actions {
 
   result: {
     show: Action<string>;
+  };
+
+  generated: {
+    workflows: {
+      highlight: Action;
+      unhighlight: Action;
+    };
   };
 
   template: {


### PR DESCRIPTION
Add highlighting functionality to draw attention to generated workflow files in .github/workflows folder. When hovering over the workflow notice in the result template, the corresponding files and folder in the generated files panel are highlighted with a warning tone.

- Add optional className prop to TFile and TFolder types in Tree component
- Implement highlight/unhighlight command handlers in PanelGeneratedFiles
- Add conditional rendering of workflow notice in

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did

Add highlighting functionality to draw attention to generated workflow files in `.github/workflows` folder. When hovering over the workflow notice in the result template, the corresponding files and folder in the generated files panel are highlighted with a warning tone.

<!--
  A clear and concise description of what you did. If applicable, add screenshots/gifs to show your UI changes
 -->
