### PR TITLE
fix(canvas): reset right panel when active section is cleared

### DIFF
--- a/src/components/handles/canvas/index.tsx
+++ b/src/components/handles/canvas/index.tsx
@@ -19,12 +19,21 @@ type HandleEditPayload = {
 };
 
 export function CanvasHandle() {
+  function deactivateSection() {
+    runInAction(() => {
+      canvasStore.activeSectionId = undefined;
+    });
+
+    actions.panel.right.show(PanelsEnum.RECOMMENDED_RESOURCES);
+  }
+
   function clear() {
     runInAction(() => {
       canvasStore.sections = [];
-      canvasStore.activeSectionId = undefined;
       canvasStore.previewSections = [];
     });
+
+    deactivateSection();
   }
 
   function handleCanvasSectionAdd(sectionType: Sections) {
@@ -63,17 +72,13 @@ export function CanvasHandle() {
     const index = canvasStore.$sectionsMap.indexById[sectionId];
     if (index === undefined) return;
 
+    const wasActive = sectionId === canvasStore.activeSectionId;
+
     runInAction(() => {
       canvasStore.sections.splice(index, 1);
-
-      if (sectionId === canvasStore.activeSectionId) {
-        canvasStore.activeSectionId = undefined;
-      }
     });
 
-    if (sectionId === canvasStore.activeSectionId) {
-      actions.panel.right.show(PanelsEnum.RECOMMENDED_RESOURCES);
-    }
+    if (wasActive) deactivateSection();
   }
 
   function handleCanvasSectionActivate(id: string) {
@@ -89,7 +94,6 @@ export function CanvasHandle() {
 
   function handleCanvasSectionsClear() {
     clear();
-    actions.panel.right.show(PanelsEnum.RECOMMENDED_RESOURCES);
     actions.settings.preview.reset();
   }
 
@@ -154,9 +158,10 @@ export function CanvasHandle() {
 
     runInAction(() => {
       canvasStore.sections = sections;
-      canvasStore.activeSectionId = undefined;
       canvasStore.previewSections = [];
     });
+
+    deactivateSection();
   }
 
   function handleCanvasPreviewApply() {

--- a/src/components/handles/canvas/test.tsx
+++ b/src/components/handles/canvas/test.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react';
+import { runInAction } from 'mobx';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { actions, command } from '#/lib/command';
+import { canvasStore } from '#/stores/canvas-store';
+import { CanvasSection, PanelsEnum, Sections } from '#/types';
+
+import { CanvasHandle } from '.';
+
+const musicSection = {
+  id: 'music-section',
+  type: Sections.MUSIC,
+  props: { content: { type: 'recently' } },
+} as unknown as CanvasSection;
+
+describe('CanvasHandle', () => {
+  const showRightPanel = vi.fn();
+  let disposeRightPanel: () => void;
+
+  beforeEach(() => {
+    showRightPanel.mockClear();
+    disposeRightPanel = command.handle('panel.right.show', showRightPanel);
+
+    render(<CanvasHandle />);
+
+    runInAction(() => {
+      canvasStore.sections = [musicSection];
+      canvasStore.activeSectionId = musicSection.id;
+      canvasStore.previewSections = [];
+    });
+  });
+
+  afterEach(() => {
+    disposeRightPanel();
+  });
+
+  it('resets the right panel when the active section is removed', async () => {
+    await actions.canvas.section.remove(musicSection.id);
+
+    expect(canvasStore.activeSectionId).toBeUndefined();
+    expect(showRightPanel).toHaveBeenCalledWith(
+      PanelsEnum.RECOMMENDED_RESOURCES
+    );
+  });
+
+  it('keeps the right panel when an inactive section is removed', async () => {
+    runInAction(() => {
+      canvasStore.sections.push({
+        ...musicSection,
+        id: 'other-section',
+      } as CanvasSection);
+    });
+
+    await actions.canvas.section.remove('other-section');
+
+    expect(canvasStore.activeSectionId).toBe(musicSection.id);
+    expect(showRightPanel).not.toHaveBeenCalled();
+  });
+
+  it('resets the right panel when a readme is imported', async () => {
+    const file = { text: async () => '' };
+
+    await actions.canvas.import.apply({
+      target: { files: [file] },
+    } as unknown as React.ChangeEvent<HTMLInputElement>);
+
+    expect(canvasStore.activeSectionId).toBeUndefined();
+    expect(showRightPanel).toHaveBeenCalledWith(
+      PanelsEnum.RECOMMENDED_RESOURCES
+    );
+  });
+});


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did

Fixed a crash where the right panel keeps rendering a section edit panel after the active section is gone.

**Repro:** add a Music section, select it, delete it.

```
Uncaught Error: Element type is invalid: expected a string (for built-in components)
or a class/function (for composite components) but got: undefined.

Check the render method of `MusicEditPanel`.
    at MusicEditPanel (src/features/music/panel/index.tsx:32:7)
    at PanelRender (src/components/organisms/panel/index.tsx:174:10)
```

### Cause

`handleCanvasSectionRemove` cleared `activeSectionId` inside a `runInAction` block, then compared against that same value to decide whether to reset the panel:

```js
runInAction(() => {
  canvasStore.sections.splice(index, 1);

  if (sectionId === canvasStore.activeSectionId) {
    canvasStore.activeSectionId = undefined;   // cleared here
  }
});

if (sectionId === canvasStore.activeSectionId) {   // always false now
  actions.panel.right.show(PanelsEnum.RECOMMENDED_RESOURCES);
}
```

The second check can never match, so the panel stays on the deleted section while `$currentSection` is `undefined`. `MusicEditPanel` then does `views[undefined]` and renders `undefined`. Any panel reading `$currentSection` is exposed the same way; Music just fails hardest because it indexes a view map.

`handleCanvasImportApply` had the same desync — it cleared `activeSectionId` and never reset the panel at all.

### Fix

Both paths (plus `clear()`) now go through a single `deactivateSection` helper that owns clearing the active section and restoring the recommended resources panel, so the reset can't drift out of sync again.

### Tests

Added `src/components/handles/canvas/test.tsx` covering the three branches: removing the active section resets the panel, removing an inactive one does not, and importing a readme resets it. `pnpm vitest run src/components/handles/canvas/test.tsx` — 3 passed.