### PR TITLE
test(utils): complete test coverage for src/utils utilities

### DIFF
--- a/src/utils/dev/dev/test.ts
+++ b/src/utils/dev/dev/test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('UTILS - Dev', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should run the callback in development', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const { dev } = await import('.');
+    const fn = vi.fn();
+
+    dev.run(fn);
+
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('should not run the callback outside development', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const { dev } = await import('.');
+    const fn = vi.fn();
+
+    dev.run(fn);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/fn/clipboard/test.ts
+++ b/src/utils/fn/clipboard/test.ts
@@ -1,23 +1,47 @@
 import { clipboard } from '.';
-import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-Object.assign(navigator, {
-  clipboard: {
-    writeText: () => null,
-  },
-});
-
-vi.spyOn(navigator.clipboard, 'writeText');
-
-describe('UTILS - Copy to clip board', () => {
+describe('UTILS - Copy to clipboard', () => {
   const input = 'some value';
 
-  beforeAll(() => {
-    clipboard(input);
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
   });
 
-  it('should be called with the correct value', () => {
-    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(input);
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should use navigator.clipboard when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    await clipboard(input);
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith(input);
+  });
+
+  it('should fallback to document.execCommand', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand as typeof document.execCommand;
+
+    await clipboard(input);
+
+    expect(execCommand).toHaveBeenCalledOnce();
+    expect(execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('should throw when execCommand is unsuccessful', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    const execCommand = vi.fn().mockReturnValue(false);
+    document.execCommand = execCommand as typeof document.execCommand;
+
+    await expect(clipboard(input)).rejects.toThrow(
+      'execCommand copy was unsuccessful'
+    );
+    expect(execCommand).toHaveBeenCalledOnce();
   });
 });

--- a/src/utils/fn/storage/test.ts
+++ b/src/utils/fn/storage/test.ts
@@ -35,6 +35,15 @@ describe('UTILS - Storage', () => {
     expect(storedValue).toStrictEqual(value);
   });
 
+  it('should remove the item from local storage', () => {
+    const key = `${APP_KEY}:${storageTestKey}`;
+    window.localStorage.setItem(key, 'value');
+
+    storage.removeItem(storageTestKey);
+
+    expect(window.localStorage.getItem(key)).toBeNull();
+  });
+
   it('should do nothing if window is undefined', () => {
     const win = global.window;
 
@@ -47,6 +56,10 @@ describe('UTILS - Storage', () => {
     expect(storedValue).toBeNull();
 
     storedValue = storage.getItem(storageTestKey);
+    expect(storedValue).toBeNull();
+
+    storage.removeItem(storageTestKey);
+    storedValue = win.localStorage.getItem(`${APP_KEY}:${storageTestKey}`);
     expect(storedValue).toBeNull();
 
     global.window = win;

--- a/src/utils/object/change-deep-property/test.ts
+++ b/src/utils/object/change-deep-property/test.ts
@@ -66,4 +66,14 @@ describe('UTILS - Deep change object property', () => {
       expect(finded).toBe(value);
     });
   });
+
+  it('should throw when the root is not an object', () => {
+    expect(() =>
+      changeDeepProperty({
+        obj: 'not an object' as any,
+        path: 'a',
+        value: 'x',
+      })
+    ).toThrow('changeDeepProperty Error: path "a" don\'t exist in object');
+  });
 });

--- a/src/utils/object/check-deep-property/test.ts
+++ b/src/utils/object/check-deep-property/test.ts
@@ -55,9 +55,18 @@ describe('UTILS - Check deep object value', () => {
         ...rest,
       });
 
-      const method = expected ? 'toBeTruthy' : 'toBeFalsy';
-
-      expect(result)[method];
+      expect(result).toBe(expected);
     });
+  });
+
+  it('should return false for an unknown operator', () => {
+    const result = checkDeepProperty({
+      obj: objInput,
+      path: 'prop1',
+      be: 'different' as any,
+      value: 'some1',
+    });
+
+    expect(result).toBe(false);
   });
 });

--- a/src/utils/parsers/from-readme/test.ts
+++ b/src/utils/parsers/from-readme/test.ts
@@ -1,0 +1,50 @@
+import { fromReadme } from '.';
+import { describe, it, expect } from 'vitest';
+
+import { Sections } from '#/types';
+
+describe('UTILS - From readme', () => {
+  it('should return an empty array when there are no importers', async () => {
+    const result = await fromReadme('## Hello');
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty array for unknown importers', async () => {
+    const result = await fromReadme(
+      '<div data-importer="unknown">content</div>'
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('should extract a section from markdown with html', async () => {
+    const result = await fromReadme('<h1 data-importer="text">Hello</h1>');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe(Sections.TEXT);
+    expect(result[0].props.content.text).toBe('Hello');
+  });
+
+  it('should ignore non-element nodes', async () => {
+    const result = await fromReadme(
+      'text<div data-importer="text">Hello</div>'
+    );
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('should ignore non-element children', async () => {
+    const result = await fromReadme(
+      '<div data-importer="text">Hello</div> extra'
+    );
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('should ignore elements without data importer', async () => {
+    const result = await fromReadme('<div>no data</div>');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/utils/parsers/to-readme/test.ts
+++ b/src/utils/parsers/to-readme/test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { toReadme } from '.';
+import { CanvasSection, CanvasStatesEnum, Sections } from '#/types';
+import type { TFile } from '#/components/atoms/tree';
+
+vi.mock('html-prettify', () => ({
+  default: (html: string) => html,
+}));
+
+const makeSection = (
+  type: Sections,
+  props: Record<string, unknown> = {}
+): CanvasSection => ({
+  id: '1',
+  type,
+  props: { content: {}, ...props },
+});
+
+const settings = { user: {} };
+
+describe('UTILS - To readme', () => {
+  it('should return the file tree with an empty readme when template is empty', () => {
+    const tree = toReadme([], undefined, settings);
+
+    expect(tree).toHaveLength(2);
+    expect(tree[0].name).toBe('.github/workflows');
+    expect(tree[0].files).toEqual([]);
+    expect(tree[1].files[0].file).toBe('README.md');
+    expect(tree[1].files[0].content).toBe('');
+  });
+
+  it('should skip sections in alert state', () => {
+    const section = makeSection(Sections.TEXT, {
+      state: CanvasStatesEnum.ALERT,
+    });
+
+    const tree = toReadme([section], undefined, settings);
+
+    expect(tree[1].files[0].content).toBe('');
+  });
+
+  it('should generate the readme with html and separators', () => {
+    const parser = { readme: () => '<p>hello</p>' };
+    const parsers = { [Sections.TEXT]: { parser } };
+
+    const tree = toReadme([makeSection(Sections.TEXT)], parsers, settings);
+
+    expect(tree[1].files[0].content).toContain('<p>hello</p>');
+    expect(tree[1].files[0].content).toContain('###');
+  });
+
+  it('should add br clear when styles.clear is set', () => {
+    const parser = { readme: () => '<p>hello</p>' };
+    const parsers = { [Sections.TEXT]: { parser } };
+
+    const tree = toReadme(
+      [makeSection(Sections.TEXT, { styles: { clear: true } })],
+      parsers,
+      settings
+    );
+
+    expect(tree[1].files[0].content).toContain('<br clear="both">');
+  });
+
+  it('should generate workflows from parsers', () => {
+    const file: TFile = { file: 'ci.yml', content: 'name: CI' };
+    const parser = { workflow: () => file };
+    const parsers = { [Sections.TEXT]: { parser } };
+
+    const tree = toReadme([makeSection(Sections.TEXT)], parsers, settings);
+
+    expect(tree[0].files).toEqual([file]);
+  });
+
+  it('should handle workflow arrays', () => {
+    const files: TFile[] = [
+      { file: 'a.yml', content: 'a' },
+      { file: 'b.yml', content: 'b' },
+    ];
+    const parser = { workflow: () => files };
+    const parsers = { [Sections.TEXT]: { parser } };
+
+    const tree = toReadme([makeSection(Sections.TEXT)], parsers, settings);
+
+    expect(tree[0].files).toEqual(files);
+  });
+
+  it('should skip sections without a parser', () => {
+    const tree = toReadme([makeSection(Sections.TEXT)], {}, settings);
+
+    expect(tree[1].files[0].content).toBe('');
+  });
+
+  it('should skip null or undefined workflows', () => {
+    const parser = { workflow: () => null };
+    const parsers = { [Sections.TEXT]: { parser } };
+
+    const tree = toReadme([makeSection(Sections.TEXT)], parsers, settings);
+
+    expect(tree[0].files).toEqual([]);
+  });
+});

--- a/src/utils/string/capitalize/test.ts
+++ b/src/utils/string/capitalize/test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+
+import { capitalize } from '.';
+
+describe('UTILS - Capitalize', () => {
+  it('should capitalize the first letter of a string', () => {
+    const inputs = [
+      { value: 'hello', expected: 'Hello' },
+      { value: 'Hello', expected: 'Hello' },
+      { value: 'a long sentence', expected: 'A long sentence' },
+      { value: '', expected: '' },
+      { value: '1number', expected: '1number' },
+    ];
+
+    inputs.forEach(({ value, expected }) => {
+      expect(capitalize(value)).toBe(expected);
+    });
+  });
+});

--- a/src/utils/tailwind/get-token/test.ts
+++ b/src/utils/tailwind/get-token/test.ts
@@ -1,0 +1,89 @@
+import { getToken } from '.';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('UTILS - Get tailwind token', () => {
+  const createStyles = (values: Record<string, string>) =>
+    ({
+      getPropertyValue: (token: string) => values[token] || '',
+    }) as CSSStyleDeclaration;
+
+  const original = globalThis.getComputedStyle;
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(() => createStyles({}))
+    );
+  });
+
+  afterEach(() => {
+    globalThis.getComputedStyle = original;
+    vi.restoreAllMocks();
+  });
+
+  it('should return the raw value of a css custom property', () => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(() => createStyles({ '--color': '#ff0000' }))
+    );
+
+    expect(getToken('--color')).toBe('#ff0000');
+  });
+
+  it('should format px values to a number', () => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(() => createStyles({ '--size': '24px' }))
+    );
+
+    expect(getToken('--size', { formatToNumber: true })).toBe(24);
+  });
+
+  it('should format rem values to a number using the html font size', () => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(() => createStyles({ '--size': '2rem', 'font-size': '10px' }))
+    );
+
+    expect(getToken('--size', { formatToNumber: true })).toBe(20);
+  });
+
+  it('should return the fallback when the token is not defined', () => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(() => createStyles({}))
+    );
+
+    expect(getToken('--missing', { fallbackReturn: 'fallback' })).toBe(
+      'fallback'
+    );
+  });
+
+  it('should return the fallback when getComputedStyle is unavailable', () => {
+    vi.stubGlobal('getComputedStyle', undefined);
+
+    expect(getToken('--color', { fallbackReturn: 'fallback' })).toBe(
+      'fallback'
+    );
+  });
+
+  it('should return the fallback for unsupported formats', () => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(() => createStyles({ '--size': '1em' }))
+    );
+
+    expect(
+      getToken('--size', { formatToNumber: true, fallbackReturn: 0 })
+    ).toBe(0);
+  });
+
+  it('should use the default html font size when font-size is not set', () => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(() => createStyles({ '--size': '1rem' }))
+    );
+
+    expect(getToken('--size', { formatToNumber: true })).toBe(16);
+  });
+});

--- a/src/utils/url/get-border/test.ts
+++ b/src/utils/url/get-border/test.ts
@@ -60,6 +60,37 @@ describe('UTILS - Get border url', () => {
         },
         expected: `${capsuleRenderBaseUrl}?theme=value`,
       },
+      {
+        input: {
+          type: 'capsule-render',
+          params: {
+            color: {
+              type: 'custom-gradient',
+              'custom-gradient': 'linear-gradient',
+            },
+          } as CapsuleRenderParams,
+        },
+        expected: `${capsuleRenderBaseUrl}?color=linear-gradient`,
+      },
+      {
+        input: {
+          type: 'capsule-render',
+          params: {
+            strokeWidth: 0,
+            color: {
+              type: 'gradient',
+            },
+          } as CapsuleRenderParams,
+        },
+        expected: `${capsuleRenderBaseUrl}?stroke=-&color=gradient`,
+      },
+      {
+        input: {
+          type: 'capsule-render',
+          params: undefined,
+        },
+        expected: `${capsuleRenderBaseUrl}?`,
+      },
     ];
 
     inputs.forEach(({ input, expected }) => {

--- a/src/utils/url/get-music/test.ts
+++ b/src/utils/url/get-music/test.ts
@@ -81,6 +81,20 @@ describe('UTILS - Get music url', () => {
           imgUrl: `some-url?bla=cat&dog=here`,
         },
       },
+
+      {
+        props: {
+          project: 'foo',
+          foo: {
+            url: 'empty-props',
+          },
+        },
+
+        expect: {
+          profileUrl: undefined,
+          imgUrl: 'empty-props?',
+        },
+      },
     ];
 
     inputs.forEach(input => {

--- a/src/utils/url/get-social-img/test.ts
+++ b/src/utils/url/get-social-img/test.ts
@@ -1,0 +1,39 @@
+import { config } from '#/config';
+import { describe, it, expect } from 'vitest';
+
+import { getSocialImg } from '.';
+
+const { iconBaseUrl, badgeBaseUrl } = config.general.urls.sections.socials;
+
+describe('UTILS - Get social image url', () => {
+  it('should return the correct icon url', () => {
+    const result = getSocialImg('icon', 'github', { icon: 'mark' });
+
+    expect(result).toBe(`${iconBaseUrl}/github/mark.svg`);
+  });
+
+  it('should return the correct badge url with default props', () => {
+    const result = getSocialImg('badge', 'github', {});
+
+    expect(result).toBe(
+      `${badgeBaseUrl}?message=Github&logo=github&label=&color=000&logoColor=white&labelColor=&style=for-the-badge`
+    );
+  });
+
+  it('should return the correct badge url with custom props', () => {
+    const result = getSocialImg('badge', 'twitter', {
+      icon: 'x',
+      message: 'follow',
+      logo: 'x',
+      label: 'x',
+      color: '111',
+      logoColor: 'blue',
+      labelColor: 'black',
+      style: 'flat',
+    });
+
+    expect(result).toBe(
+      `${badgeBaseUrl}?message=follow&logo=x&label=x&color=111&logoColor=blue&labelColor=black&style=flat`
+    );
+  });
+});


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update
- [x] Test

## What I did

Completed the test coverage Epic for `src/utils` utilities.

- Added missing tests for `getSocialImg`, `getBorder` (custom-gradient and `strokeWidth === 0`), `getMusic` (missing nested props branch), `capitalize`, `dev`, `getToken`, `fromReadme` and `toReadme`.
- Refined existing tests for `clipboard` (navigator + execCommand fallback), `storage` (`removeItem` and SSR guard), `changeDeepProperty` (error path) and `checkDeepProperty` (unknown operator branch).
- All added tests follow the existing `describe('UTILS - ...')` pattern and import from `.`.

## Verification

- `pnpm vitest run` passes (68 tests).
- `biome check src` passes (pre-existing warnings only).
- `biome format src` passes with no fixes needed.
- Coverage for the targeted utility files reaches 100%.

Closes #215
Closes #216
Closes #217
Closes #218
Closes #219

Generated with [Devin](https://devin.ai)