### PR TITLE
🤖 test: add unit tests for canvas, extensions and settings stores and handles

### DIFF
--- a/src/components/handles/canvas/index.tsx
+++ b/src/components/handles/canvas/index.tsx
@@ -38,7 +38,7 @@ export function CanvasHandle() {
 
   function handleCanvasSectionAdd(sectionType: Sections) {
     const sectionData = extensionsStore.extensions.sections?.[sectionType] as
-      | Record<string, unknown>
+      | Record<string, object>
       | undefined;
 
     const newSection = {

--- a/src/components/handles/canvas/test.tsx
+++ b/src/components/handles/canvas/test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { actions, command } from '#/lib/command';
 import { canvasStore } from '#/stores/canvas-store';
+import { extensionsStore } from '#/stores/extensions-store';
 import { CanvasSection, PanelsEnum, Sections } from '#/types';
 
 import { CanvasHandle } from '.';
@@ -14,31 +15,69 @@ const musicSection = {
   props: { content: { type: 'recently' } },
 } as unknown as CanvasSection;
 
+function resetCanvasStore() {
+  runInAction(() => {
+    canvasStore.sections = [];
+    canvasStore.activeSectionId = undefined;
+    canvasStore.previewSections = [];
+  });
+}
+
+function resetExtensionsStore() {
+  runInAction(() => {
+    extensionsStore.extensions = {};
+    extensionsStore.registers = {};
+  });
+}
+
 describe('CanvasHandle', () => {
   const showRightPanel = vi.fn();
+  const applySettingsPreview = vi.fn();
+  const resetSettingsPreview = vi.fn();
   let disposeRightPanel: () => void;
+  let disposeApply: () => void;
+  let disposeReset: () => void;
+  let unmount: () => void;
 
   beforeEach(() => {
+    window.localStorage.clear();
+    resetCanvasStore();
+    resetExtensionsStore();
+
     showRightPanel.mockClear();
+    applySettingsPreview.mockClear();
+    resetSettingsPreview.mockClear();
+
     disposeRightPanel = command.handle('panel.right.show', showRightPanel);
+    disposeApply = command.handle(
+      'settings.preview.apply',
+      applySettingsPreview
+    );
+    disposeReset = command.handle(
+      'settings.preview.reset',
+      resetSettingsPreview
+    );
 
-    render(<CanvasHandle />);
-
-    runInAction(() => {
-      canvasStore.sections = [musicSection];
-      canvasStore.activeSectionId = musicSection.id;
-      canvasStore.previewSections = [];
-    });
+    ({ unmount } = render(<CanvasHandle />));
   });
 
   afterEach(() => {
+    unmount();
     disposeRightPanel();
+    disposeApply();
+    disposeReset();
   });
 
   it('resets the right panel when the active section is removed', async () => {
+    runInAction(() => {
+      canvasStore.sections = [musicSection];
+      canvasStore.activeSectionId = musicSection.id;
+    });
+
     await actions.canvas.section.remove(musicSection.id);
 
     expect(canvasStore.activeSectionId).toBeUndefined();
+    expect(canvasStore.sections).toHaveLength(0);
     expect(showRightPanel).toHaveBeenCalledWith(
       PanelsEnum.RECOMMENDED_RESOURCES
     );
@@ -46,15 +85,17 @@ describe('CanvasHandle', () => {
 
   it('keeps the right panel when an inactive section is removed', async () => {
     runInAction(() => {
-      canvasStore.sections.push({
-        ...musicSection,
-        id: 'other-section',
-      } as CanvasSection);
+      canvasStore.sections = [
+        musicSection,
+        { ...musicSection, id: 'other-section' } as CanvasSection,
+      ];
+      canvasStore.activeSectionId = musicSection.id;
     });
 
     await actions.canvas.section.remove('other-section');
 
     expect(canvasStore.activeSectionId).toBe(musicSection.id);
+    expect(canvasStore.sections).toHaveLength(1);
     expect(showRightPanel).not.toHaveBeenCalled();
   });
 
@@ -66,8 +107,175 @@ describe('CanvasHandle', () => {
     } as unknown as React.ChangeEvent<HTMLInputElement>);
 
     expect(canvasStore.activeSectionId).toBeUndefined();
+    expect(canvasStore.sections).toHaveLength(0);
     expect(showRightPanel).toHaveBeenCalledWith(
       PanelsEnum.RECOMMENDED_RESOURCES
     );
+  });
+
+  it('adds a section with default config from extensions', async () => {
+    const defaultConfig = { props: { content: { text: 'Default' } } };
+
+    runInAction(() => {
+      extensionsStore.extensions = {
+        sections: { text: { defaultConfig } },
+      };
+    });
+
+    await actions.canvas.section.add(Sections.TEXT);
+
+    expect(canvasStore.sections).toHaveLength(1);
+    expect(canvasStore.sections[0].type).toBe(Sections.TEXT);
+    expect(canvasStore.sections[0].props.content).toEqual({ text: 'Default' });
+  });
+
+  it('edits the active section props using a deep path', async () => {
+    runInAction(() => {
+      canvasStore.sections = [musicSection];
+      canvasStore.activeSectionId = musicSection.id;
+    });
+
+    await actions.canvas.section.edit({ path: 'content.type', value: 'top' });
+
+    expect(canvasStore.sections[0].props.content.type).toBe('top');
+  });
+
+  it('edits the active section props using props prefix', async () => {
+    runInAction(() => {
+      canvasStore.sections = [musicSection];
+      canvasStore.activeSectionId = musicSection.id;
+    });
+
+    await actions.canvas.section.edit({
+      path: 'props.content.type',
+      value: 'top',
+    });
+
+    expect(canvasStore.sections[0].props.content.type).toBe('top');
+  });
+
+  it('activates a section and opens the right panel', async () => {
+    runInAction(() => {
+      canvasStore.sections = [musicSection];
+    });
+
+    await actions.canvas.section.activate(musicSection.id);
+
+    expect(canvasStore.activeSectionId).toBe(musicSection.id);
+    expect(showRightPanel).toHaveBeenCalledWith(musicSection.type);
+  });
+
+  it('duplicates a section next to the original', async () => {
+    runInAction(() => {
+      canvasStore.sections = [musicSection];
+    });
+
+    await actions.canvas.section.duplicate(musicSection.id);
+
+    expect(canvasStore.sections).toHaveLength(2);
+    expect(canvasStore.sections[0].id).toBe(musicSection.id);
+    expect(canvasStore.sections[1].type).toBe(Sections.MUSIC);
+    expect(canvasStore.sections[1].props.content.type).toBe('recently');
+    expect(canvasStore.sections[1].id).not.toBe(musicSection.id);
+  });
+
+  it('moves a section up', async () => {
+    const first = { ...musicSection, id: 'first', type: Sections.TEXT };
+    const second = { ...musicSection, id: 'second' };
+
+    runInAction(() => {
+      canvasStore.sections = [first, second] as CanvasSection[];
+    });
+
+    await actions.canvas.section.moveUp('second');
+
+    expect(canvasStore.sections[0].id).toBe('second');
+    expect(canvasStore.sections[1].id).toBe('first');
+  });
+
+  it('moves a section down', async () => {
+    const first = { ...musicSection, id: 'first', type: Sections.TEXT };
+    const second = { ...musicSection, id: 'second' };
+
+    runInAction(() => {
+      canvasStore.sections = [first, second] as CanvasSection[];
+    });
+
+    await actions.canvas.section.moveDown('first');
+
+    expect(canvasStore.sections[0].id).toBe('second');
+    expect(canvasStore.sections[1].id).toBe('first');
+  });
+
+  it('reorders sections', async () => {
+    const a = { ...musicSection, id: 'a' };
+    const b = { ...musicSection, id: 'b' };
+    const c = { ...musicSection, id: 'c' };
+
+    runInAction(() => {
+      canvasStore.sections = [a, b, c] as CanvasSection[];
+    });
+
+    await actions.canvas.sections.reorder(['c', 'a', 'b']);
+
+    expect(canvasStore.sections[0].id).toBe('c');
+    expect(canvasStore.sections[1].id).toBe('a');
+    expect(canvasStore.sections[2].id).toBe('b');
+  });
+
+  it('clears all sections and resets the right panel', async () => {
+    runInAction(() => {
+      canvasStore.sections = [musicSection];
+      canvasStore.activeSectionId = musicSection.id;
+      canvasStore.previewSections = [
+        { id: 'p1', type: Sections.BORDER, props: { content: {} } },
+      ] as CanvasSection[];
+    });
+
+    await actions.canvas.sections.clear();
+
+    expect(canvasStore.sections).toHaveLength(0);
+    expect(canvasStore.previewSections).toHaveLength(0);
+    expect(canvasStore.activeSectionId).toBeUndefined();
+    expect(showRightPanel).toHaveBeenCalledWith(
+      PanelsEnum.RECOMMENDED_RESOURCES
+    );
+    expect(resetSettingsPreview).toHaveBeenCalled();
+  });
+
+  it('previews a section template and enables settings preview', async () => {
+    const template = [{ ...musicSection, id: 'template' }] as CanvasSection[];
+
+    runInAction(() => {
+      canvasStore.sections = [];
+      canvasStore.activeSectionId = undefined;
+    });
+
+    await actions.canvas.preview.sections(template);
+
+    expect(canvasStore.previewSections).toHaveLength(1);
+    expect(canvasStore.$isInPreviewMode).toBe(true);
+    expect(canvasStore.previewSections[0].type).toBe(Sections.MUSIC);
+    expect(canvasStore.previewSections[0].id).not.toBe('template');
+    expect(applySettingsPreview).toHaveBeenCalled();
+  });
+
+  it('applies preview sections and resets the preview state', async () => {
+    const preview = [
+      { id: 'p1', type: Sections.BORDER, props: { content: {} } },
+    ];
+
+    runInAction(() => {
+      canvasStore.sections = [musicSection];
+      canvasStore.activeSectionId = musicSection.id;
+      canvasStore.previewSections = preview as CanvasSection[];
+    });
+
+    await actions.canvas.preview.apply();
+
+    expect(canvasStore.sections).toHaveLength(1);
+    expect(canvasStore.sections[0].type).toBe(Sections.BORDER);
+    expect(canvasStore.previewSections).toHaveLength(0);
+    expect(resetSettingsPreview).toHaveBeenCalled();
   });
 });

--- a/src/components/handles/extensions/test.tsx
+++ b/src/components/handles/extensions/test.tsx
@@ -1,0 +1,70 @@
+import { render } from '@testing-library/react';
+import { runInAction } from 'mobx';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { actions } from '#/lib/command';
+import { extensionsStore } from '#/stores/extensions-store';
+import { Extension } from '#/types';
+
+import { ExtensionsHandle } from '.';
+
+const extensionA: Extension = {
+  id: 'a',
+  presentation: { sections: { text: {} } },
+};
+
+const extensionB: Extension = {
+  id: 'b',
+  presentation: {
+    sections: { music: {} },
+    widgets: { badge: {} },
+  },
+};
+
+function resetExtensionsStore() {
+  runInAction(() => {
+    extensionsStore.extensions = {};
+    extensionsStore.registers = {};
+  });
+}
+
+describe('ExtensionsHandle', () => {
+  let unmount: () => void;
+
+  beforeEach(() => {
+    resetExtensionsStore();
+    ({ unmount } = render(<ExtensionsHandle />));
+  });
+
+  afterEach(() => {
+    unmount();
+  });
+
+  it('registers a single extension', async () => {
+    await actions.extensions.register(extensionA);
+
+    expect(extensionsStore.registers.a).toEqual(extensionA);
+    expect(extensionsStore.extensions.sections.a).toEqual({ text: {} });
+  });
+
+  it('registers an array of extensions', async () => {
+    await actions.extensions.register([extensionA, extensionB]);
+
+    expect(extensionsStore.registers.a).toEqual(extensionA);
+    expect(extensionsStore.registers.b).toEqual(extensionB);
+    expect(extensionsStore.extensions.sections.a).toEqual({ text: {} });
+    expect(extensionsStore.extensions.sections.b).toEqual({ music: {} });
+    expect(extensionsStore.extensions.widgets.b).toEqual({ badge: {} });
+  });
+
+  it('merges multiple registrations without overwriting unrelated groups', async () => {
+    await actions.extensions.register(extensionA);
+    await actions.extensions.register(extensionB);
+
+    expect(extensionsStore.registers.a).toEqual(extensionA);
+    expect(extensionsStore.registers.b).toEqual(extensionB);
+    expect(extensionsStore.extensions.sections.a).toEqual({ text: {} });
+    expect(extensionsStore.extensions.sections.b).toEqual({ music: {} });
+    expect(extensionsStore.extensions.widgets.b).toEqual({ badge: {} });
+  });
+});

--- a/src/components/handles/settings/test.tsx
+++ b/src/components/handles/settings/test.tsx
@@ -1,0 +1,61 @@
+import { render } from '@testing-library/react';
+import { runInAction } from 'mobx';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { actions } from '#/lib/command';
+import { config } from '#/config';
+import { settingsStore } from '#/stores/settings-store';
+
+import { SettingsHandle } from '.';
+
+const { initial: INITIAL_SETTINGS, preview: PREVIEW_SETTINGS } =
+  config.general.settings;
+
+function resetSettingsStore() {
+  window.localStorage.clear();
+
+  runInAction(() => {
+    settingsStore.settings = { ...INITIAL_SETTINGS };
+    settingsStore.__previewMode = false;
+  });
+}
+
+describe('SettingsHandle', () => {
+  let unmount: () => void;
+
+  beforeEach(() => {
+    resetSettingsStore();
+    ({ unmount } = render(<SettingsHandle />));
+  });
+
+  afterEach(() => {
+    unmount();
+  });
+
+  it('dispatches settings.edit and updates a nested path', async () => {
+    await actions.settings.edit({ path: 'user.github', value: 'new' });
+
+    expect(settingsStore.settings.user.github).toBe('new');
+  });
+
+  it('dispatches settings.preview.apply and activates preview mode', async () => {
+    await actions.settings.preview.apply();
+
+    expect(settingsStore.__previewMode).toBe(true);
+    expect(settingsStore.$settings).toEqual({
+      ...INITIAL_SETTINGS,
+      ...PREVIEW_SETTINGS,
+    });
+  });
+
+  it('dispatches settings.preview.reset and deactivates preview mode', async () => {
+    runInAction(() => {
+      settingsStore.__previewMode = true;
+    });
+
+    await actions.settings.preview.reset();
+
+    expect(settingsStore.__previewMode).toBe(false);
+    expect(settingsStore.$settings).toEqual(INITIAL_SETTINGS);
+  });
+});

--- a/src/stores/canvas-store/test.ts
+++ b/src/stores/canvas-store/test.ts
@@ -1,0 +1,94 @@
+import { runInAction } from 'mobx';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { canvasStore } from '.';
+import { Sections } from '#/types';
+
+const sampleSections = [
+  { id: 's1', type: Sections.TEXT, props: { content: {} } },
+  { id: 's2', type: Sections.MUSIC, props: { content: {} } },
+];
+
+function resetCanvasStore() {
+  runInAction(() => {
+    canvasStore.sections = [];
+    canvasStore.activeSectionId = undefined;
+    canvasStore.previewSections = [];
+  });
+}
+
+describe('CanvasStore', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    resetCanvasStore();
+  });
+
+  it('$isInPreviewMode is false when previewSections is empty', () => {
+    runInAction(() => {
+      canvasStore.previewSections = [];
+    });
+
+    expect(canvasStore.$isInPreviewMode).toBe(false);
+  });
+
+  it('$isInPreviewMode is true when previewSections has items', () => {
+    runInAction(() => {
+      canvasStore.previewSections = sampleSections;
+    });
+
+    expect(canvasStore.$isInPreviewMode).toBe(true);
+  });
+
+  it('$canvas returns sections when not in preview', () => {
+    runInAction(() => {
+      canvasStore.sections = sampleSections;
+      canvasStore.previewSections = [];
+    });
+
+    expect(canvasStore.$canvas).toEqual(sampleSections);
+  });
+
+  it('$canvas returns previewSections when in preview', () => {
+    const preview = [
+      { id: 'p1', type: Sections.BORDER, props: { content: {} } },
+    ];
+
+    runInAction(() => {
+      canvasStore.sections = sampleSections;
+      canvasStore.previewSections = preview;
+    });
+
+    expect(canvasStore.$canvas).toEqual(preview);
+  });
+
+  it('$sectionsMap builds byId and indexById', () => {
+    runInAction(() => {
+      canvasStore.sections = sampleSections;
+    });
+
+    const map = canvasStore.$sectionsMap;
+
+    expect(map.byId.s1).toEqual(sampleSections[0]);
+    expect(map.byId.s2).toEqual(sampleSections[1]);
+    expect(map.indexById.s1).toBe(0);
+    expect(map.indexById.s2).toBe(1);
+  });
+
+  it('$currentSection returns the active section', () => {
+    runInAction(() => {
+      canvasStore.sections = sampleSections;
+      canvasStore.activeSectionId = 's1';
+    });
+
+    expect(canvasStore.$currentSection).toEqual(sampleSections[0]);
+  });
+
+  it('$currentSection returns undefined when no active section', () => {
+    runInAction(() => {
+      canvasStore.sections = sampleSections;
+      canvasStore.activeSectionId = undefined;
+    });
+
+    expect(canvasStore.$currentSection).toBeUndefined();
+  });
+});

--- a/src/stores/extensions-store/test.ts
+++ b/src/stores/extensions-store/test.ts
@@ -1,0 +1,48 @@
+import { runInAction } from 'mobx';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { extensionsStore } from '.';
+import { Extension } from '#/types';
+
+const exampleExtension: Extension = {
+  id: 'ext-1',
+  presentation: {
+    sections: { text: { defaultConfig: { props: { content: {} } } } },
+  },
+};
+
+function resetExtensionsStore() {
+  runInAction(() => {
+    extensionsStore.extensions = {};
+    extensionsStore.registers = {};
+  });
+}
+
+describe('ExtensionsStore', () => {
+  beforeEach(resetExtensionsStore);
+
+  it('starts with empty registers and extensions', () => {
+    expect(extensionsStore.registers).toEqual({});
+    expect(extensionsStore.extensions).toEqual({});
+  });
+
+  it('holds a registered extension by id', () => {
+    runInAction(() => {
+      extensionsStore.registers = { 'ext-1': exampleExtension };
+    });
+
+    expect(extensionsStore.registers['ext-1']).toEqual(exampleExtension);
+  });
+
+  it('groups extensions by presentation key under extension id', () => {
+    runInAction(() => {
+      extensionsStore.extensions = {
+        sections: { 'ext-1': exampleExtension.presentation.sections },
+      };
+    });
+
+    expect(extensionsStore.extensions.sections['ext-1']).toEqual(
+      exampleExtension.presentation.sections
+    );
+  });
+});

--- a/src/stores/settings-store/test.ts
+++ b/src/stores/settings-store/test.ts
@@ -1,0 +1,56 @@
+import { runInAction } from 'mobx';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { settingsStore } from '.';
+import { config } from '#/config';
+
+const { initial: INITIAL_SETTINGS, preview: PREVIEW_SETTINGS } =
+  config.general.settings;
+
+function resetSettingsStore() {
+  window.localStorage.clear();
+
+  runInAction(() => {
+    settingsStore.settings = { ...INITIAL_SETTINGS };
+    settingsStore.__previewMode = false;
+  });
+}
+
+describe('SettingsStore', () => {
+  beforeEach(resetSettingsStore);
+
+  it('$settings returns the initial settings normally', () => {
+    expect(settingsStore.$settings).toEqual(INITIAL_SETTINGS);
+  });
+
+  it('$settings merges preview values when preview mode is active', () => {
+    runInAction(() => {
+      settingsStore.__previewMode = true;
+    });
+
+    expect(settingsStore.$settings).toEqual({
+      ...INITIAL_SETTINGS,
+      ...PREVIEW_SETTINGS,
+    });
+  });
+
+  it('edit applies a deep path update', () => {
+    settingsStore.edit('user.github', 'testuser');
+
+    expect(settingsStore.settings.user.github).toBe('testuser');
+  });
+
+  it('edit can replace a top-level path', () => {
+    settingsStore.edit('user', { github: 'another' });
+
+    expect(settingsStore.settings.user).toEqual({ github: 'another' });
+  });
+
+  it('applyPreview and resetPreview toggle the preview state', () => {
+    settingsStore.applyPreview();
+    expect(settingsStore.__previewMode).toBe(true);
+
+    settingsStore.resetPreview();
+    expect(settingsStore.__previewMode).toBe(false);
+  });
+});


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation Update

## What I did

Added focused unit tests for the canvas, extensions and settings MobX stores and their command handles.

- `CanvasStore` and `CanvasHandle`
- `ExtensionsStore` and `ExtensionsHandle`
- `SettingsStore` and `SettingsHandle`

Tests cover observable state, derived getters (`$isInPreviewMode`, `$canvas`, `$sectionsMap`, `$currentSection`, `$settings`) and command-driven side effects.

### Verification

- `pnpm vitest run` passes with 100 tests
- `pnpm lint` passes

### Notes

Each test resets singleton store state, clears `localStorage`, and unmounts rendered handles to avoid cross-test contamination.

Closes #231
Closes #232
Closes #233
Closes #234

Requested by: @maurodesouza
