### PR TITLE
✨ feat: add GenerateReadmeButton component with empty state validation

### DIFF
--- a/playwright/e2e/canvas.spec.ts
+++ b/playwright/e2e/canvas.spec.ts
@@ -23,6 +23,18 @@ test('editing a text section updates the preview', async ({ page }) => {
   await expect(section).toContainText(newText);
 });
 
+test('generate readme button is disabled when canvas is empty', async ({
+  page,
+}) => {
+  const button = page.getByRole('button', { name: /Generate README/i });
+  await expect(button).toBeVisible();
+  await expect(button).toBeDisabled();
+
+  await expect(
+    page.getByRole('link', { name: /Generate README/i })
+  ).toHaveCount(0);
+});
+
 test('stats guard disappears after setting the github username', async ({
   page,
 }) => {

--- a/src/components/molecules/generate-readme-button/index.tsx
+++ b/src/components/molecules/generate-readme-button/index.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { observer } from 'mobx-react-lite';
+import { useTranslations } from 'next-intl';
+
+import { Clickable } from '#/components/atoms/clickable';
+import { useCanvas } from '#/hooks';
+
+export const GenerateReadmeButton = observer(function GenerateReadmeButton() {
+  const t = useTranslations('ui');
+  const canvasStore = useCanvas();
+
+  const isEmpty = canvasStore.$isEmpty;
+
+  if (isEmpty) {
+    return (
+      <Clickable.Button
+        tone="success"
+        disabled
+        title={t('canvas.generate-readme-empty')}
+      >
+        {t('canvas.generate-readme')}
+      </Clickable.Button>
+    );
+  }
+
+  return (
+    <Clickable.Link tone="success" href="/result" prefetch={false}>
+      {t('canvas.generate-readme')}
+    </Clickable.Link>
+  );
+});

--- a/src/components/templates/canvas/index.tsx
+++ b/src/components/templates/canvas/index.tsx
@@ -1,18 +1,14 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
-
 import { Canvas } from '#/components/organisms/canvas';
 import { Page } from '#/components/atoms/page';
 import { Panel } from '#/components/organisms/panel';
 import { PageFooter } from '#/components/molecules/page-footer';
-import { Clickable } from '#/components/atoms/clickable';
+import { GenerateReadmeButton } from '#/components/molecules/generate-readme-button';
 
 import { PanelsEnum } from '#/types';
 
 const CanvasTemplate = () => {
-  const t = useTranslations('ui');
-
   return (
     <Page.Container>
       <Panel.Template.Full initialPanel={PanelsEnum.NEW_SECTION} side="left" />
@@ -26,9 +22,7 @@ const CanvasTemplate = () => {
           <PageFooter.Owner />
           <PageFooter.Navs />
 
-          <Clickable.Link tone="success" href="/result" prefetch={false}>
-            {t('canvas.generate-readme')}
-          </Clickable.Link>
+          <GenerateReadmeButton />
         </PageFooter.Container>
       </Page.Wrapper>
 

--- a/src/stores/canvas-store/index.ts
+++ b/src/stores/canvas-store/index.ts
@@ -21,6 +21,10 @@ class CanvasStore {
     }
   }
 
+  get $isEmpty() {
+    return this.sections.length === 0;
+  }
+
   get $isInPreviewMode() {
     return this.previewSections.length > 0;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -32,7 +32,8 @@
       "label": "Select the stats to config"
     },
     "canvas": {
-      "generate-readme": "Generate README"
+      "generate-readme": "Generate README",
+      "generate-readme-empty": "Add sections to your canvas first"
     },
     "result": {
       "heading": "Your Readme is Done 🎉🎉🎉",


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/maurodesouza/profile-readme-generator/blob/main/.github/CONTRIBUTING.md#commiting
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - 🔗 Provide issue number with link.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did

I've created a validation to avoid generating a README with an empty canvas

<!--
  A clear and concise description of what you did. If applicable, add screenshots/gifs to show your UI changes
 -->
