### PR TITLE
test: add unit and component tests for the text feature

### DIFF
--- a/src/features/text/importer/test.ts
+++ b/src/features/text/importer/test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+
+import { Sections } from '#/types';
+import { defaultTextSectionConfig } from '../default-config';
+
+import { textImporter } from '../importer';
+
+const makeTextElement = ({
+  tagName = 'p',
+  value = 'Hello',
+  align = 'left',
+  children,
+}: {
+  tagName?: string;
+  value?: string;
+  align?: string;
+  children?: unknown[];
+} = {}) => ({
+  type: 'element',
+  tagName,
+  properties: { align },
+  children: children ?? [{ type: 'text', value }],
+});
+
+describe('FEATURE - text importer', () => {
+  it('returns null when the input element has no children', () => {
+    const element = makeTextElement({ children: [] });
+
+    expect(textImporter(element as any)).toBeNull();
+  });
+
+  it('sets content.as to the lowercased tagName of the input element', () => {
+    const element = makeTextElement({ tagName: 'H1' });
+
+    const result = textImporter(element as any);
+
+    expect(result?.props.content.as).toBe('h1');
+  });
+
+  it('sets content.text to the value of the first text child', () => {
+    const element = makeTextElement({ value: 'My text content' });
+
+    const result = textImporter(element as any);
+
+    expect(result?.props.content.text).toBe('My text content');
+  });
+
+  it('sets styles.align from the element align property', () => {
+    const element = makeTextElement({ align: 'center' });
+
+    const result = textImporter(element as any);
+
+    expect(result?.props.styles.align).toBe('center');
+  });
+
+  it('returns a CanvasSection with type Sections.TEXT and a string id', () => {
+    const element = makeTextElement();
+
+    const result = textImporter(element as any);
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe(Sections.TEXT);
+    expect(typeof result?.id).toBe('string');
+    expect(result?.id).not.toBe('');
+  });
+
+  it('produces independent config objects across calls (no shared references)', () => {
+    const element = makeTextElement({ value: 'First' });
+    const element2 = makeTextElement({ value: 'Second' });
+
+    const result1 = textImporter(element as any);
+    const result2 = textImporter(element2 as any);
+
+    expect(result1?.id).not.toBe(result2?.id);
+    expect(result1?.props.content.text).toBe('First');
+    expect(result2?.props.content.text).toBe('Second');
+    expect(result1?.props).not.toBe(result2?.props);
+    expect(result1?.props.content).not.toBe(result2?.props.content);
+  });
+
+  it('does not mutate the shared defaultTextSectionConfig', () => {
+    const snapshot = structuredClone(defaultTextSectionConfig);
+
+    textImporter(
+      makeTextElement({
+        tagName: 'h3',
+        value: 'Changed',
+        align: 'right',
+      }) as any
+    );
+    textImporter(
+      makeTextElement({ tagName: 'h2', value: 'Again', align: 'center' }) as any
+    );
+
+    expect(defaultTextSectionConfig).toEqual(snapshot);
+  });
+});

--- a/src/features/text/panel/test.tsx
+++ b/src/features/text/panel/test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { TextEditPanel } from '../panel';
+
+vi.mock('#/components/organisms/group-fields', () => ({
+  GroupFields: ({ id, label }: { id: number; label: string }) => (
+    <div data-testid="group-fields" data-group-id={id} data-label={label} />
+  ),
+}));
+
+describe('FEATURE - TextEditPanel', () => {
+  it('renders one GroupFields per group defined in panel/fields', () => {
+    render(<TextEditPanel />);
+
+    const groups = screen.getAllByTestId('group-fields');
+
+    expect(groups).toHaveLength(2);
+  });
+
+  it('renders the Layout group with id 1', () => {
+    render(<TextEditPanel />);
+
+    const layoutGroup = screen
+      .getAllByTestId('group-fields')
+      .find(el => el.getAttribute('data-label') === 'Layout');
+
+    expect(layoutGroup).toBeDefined();
+    expect(layoutGroup?.getAttribute('data-group-id')).toBe('1');
+  });
+
+  it('renders the Content group with id 2', () => {
+    render(<TextEditPanel />);
+
+    const contentGroup = screen
+      .getAllByTestId('group-fields')
+      .find(el => el.getAttribute('data-label') === 'Content');
+
+    expect(contentGroup).toBeDefined();
+    expect(contentGroup?.getAttribute('data-group-id')).toBe('2');
+  });
+});

--- a/src/features/text/parser/test.ts
+++ b/src/features/text/parser/test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+
+import { Sections } from '#/types';
+
+import { textSectionParser } from '../parser';
+
+describe('FEATURE - text parser', () => {
+  it('wraps the trimmed text in the tag provided by content.as', () => {
+    const result = textSectionParser({
+      content: { text: 'Hello World', as: 'p' },
+      styles: { align: 'left' },
+    });
+
+    expect(result).toBe(
+      `<p data-importer="${Sections.TEXT}" align="left">Hello World</p>`
+    );
+  });
+
+  it('renders an h1 tag when content.as is h1', () => {
+    const result = textSectionParser({
+      content: { text: 'Title', as: 'h1' },
+      styles: { align: 'center' },
+    });
+
+    expect(result).toBe(
+      `<h1 data-importer="${Sections.TEXT}" align="center">Title</h1>`
+    );
+  });
+
+  it('emits the data-importer attribute with the text section value', () => {
+    const result = textSectionParser({
+      content: { text: 'Hello', as: 'p' },
+      styles: { align: 'left' },
+    });
+
+    expect(result).toContain(`data-importer="${Sections.TEXT}"`);
+  });
+
+  it('emits the align attribute from styles.align for left, center and right', () => {
+    const cases = ['left', 'center', 'right'] as const;
+
+    for (const align of cases) {
+      const result = textSectionParser({
+        content: { text: 'Hello', as: 'p' },
+        styles: { align },
+      });
+
+      expect(result).toContain(`align="${align}"`);
+    }
+  });
+
+  it('trims leading and trailing whitespace from content.text', () => {
+    const result = textSectionParser({
+      content: { text: '   Hello World   ', as: 'p' },
+      styles: { align: 'left' },
+    });
+
+    expect(result).toBe(
+      `<p data-importer="${Sections.TEXT}" align="left">Hello World</p>`
+    );
+  });
+
+  it('converts newline characters to <br> inside the rendered text', () => {
+    const result = textSectionParser({
+      content: { text: 'line1\nline2\nline3', as: 'p' },
+      styles: { align: 'left' },
+    });
+
+    expect(result).toContain('line1<br>line2<br>line3');
+    expect(result).not.toContain('\n');
+  });
+
+  it('does not mutate the input arguments', () => {
+    const args = {
+      content: { text: '  Hello\nWorld  ', as: 'h2' },
+      styles: { align: 'right' },
+    };
+
+    const argsCopy = structuredClone(args);
+
+    textSectionParser(args);
+
+    expect(args).toEqual(argsCopy);
+  });
+});

--- a/src/features/text/section/test.tsx
+++ b/src/features/text/section/test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+
+import { TextSection } from '../section';
+
+describe('FEATURE - TextSection', () => {
+  it('renders a p tag when content.as is p', () => {
+    const { container } = render(
+      <TextSection
+        content={{ text: 'Hello World', as: 'p' }}
+        styles={{ align: 'left' }}
+      />
+    );
+
+    const tag = container.querySelector('p');
+
+    expect(tag).not.toBeNull();
+    expect(tag?.textContent).toBe('Hello World');
+  });
+
+  it('renders an h1 tag when content.as is h1', () => {
+    const { container } = render(
+      <TextSection
+        content={{ text: 'Title', as: 'h1' }}
+        styles={{ align: 'center' }}
+      />
+    );
+
+    const tag = container.querySelector('h1');
+
+    expect(tag).not.toBeNull();
+    expect(tag?.textContent).toBe('Title');
+    expect(container.querySelector('p')).toBeNull();
+  });
+
+  it('trims leading and trailing whitespace from content.text', () => {
+    const { container } = render(
+      <TextSection
+        content={{ text: '   Hello World   ', as: 'p' }}
+        styles={{ align: 'left' }}
+      />
+    );
+
+    expect(container.querySelector('p')?.textContent).toBe('Hello World');
+  });
+
+  it('applies textAlign inline style from styles.align for left, center and right', () => {
+    const cases = ['left', 'center', 'right'] as const;
+
+    for (const align of cases) {
+      const { container } = render(
+        <TextSection content={{ text: 'Hello', as: 'p' }} styles={{ align }} />
+      );
+
+      expect(container.querySelector('p')?.style.textAlign).toBe(align);
+    }
+  });
+
+  it('renders the container div with the text-section class', () => {
+    const { container } = render(
+      <TextSection
+        content={{ text: 'Hello', as: 'p' }}
+        styles={{ align: 'left' }}
+      />
+    );
+
+    expect(container.querySelector('.text-section')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation Update

## What I did

Added a focused test battery for the `text` feature (`src/features/text`), covering its pure logic layer (parser and importer) and its React rendering layer (TextSection and TextEditPanel). This is the first feature in a broader effort to bring test coverage to every feature module.

### Test files added

- `src/features/text/parser/test.ts` (7 tests) — `textSectionParser`: tag wrapping, `data-importer` attribute, `align` attribute for all values, text trimming, `\n` → `<br>` conversion, input immutability.
- `src/features/text/importer/test.ts` (7 tests) — `textImporter`: null on empty children, lowercased tagName, first text child value, align property, `Sections.TEXT` type and string id, independent config objects across calls, shared default config immutability.
- `src/features/text/section/test.tsx` (5 tests) — `TextSection`: dynamic tag rendering (p and h1), text trimming, `textAlign` inline style for all align values, container `text-section` class.
- `src/features/text/panel/test.tsx` (3 tests) — `TextEditPanel`: renders one `GroupFields` per group with correct ids and labels (mocking `GroupFields` to keep the test focused on panel wiring).

All tests import modules directly (`../parser`, `../importer`, `../section`, `../panel`) to avoid the `actions.extensions.register` side effect in the feature `index.ts`.

Closes #245
Closes #246
Closes #247

### Verification

- [x] `pnpm test --coverage=false` — 35 files, 145 tests pass (22 new tests added)
- [x] `pnpm lint` — 0 errors (62 pre-existing `noExplicitAny` warnings, consistent with codebase)
- [x] `pnpm build` — succeeds

### Notes

- No production code was modified — all changes are purely additive test files.
- `TextEditPanel` test mocks `#/components/organisms/group-fields` to avoid pulling in its heavy dependency tree (MobX, framer-motion, hooks, command system) and to avoid testing an internal organism.
- `textImporter` uses `uuid` and `structuredClone`; tests assert shape and reference independence rather than exact UUID values.

Requested by: @maurodesouza

Generated with [Devin](https://devin.ai)