### PR TITLE
test: add tests for remaining features (activities, music, pacman, snake, socials, stats, techs)

### DIFF
--- a/src/features/activities/importer/test.ts
+++ b/src/features/activities/importer/test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+
+import { Sections } from '#/types';
+import { defaultActivitiesSectionConfig } from '../default-config';
+
+import { activitiesImporter } from '../importer';
+
+const makeAnchor = (href: string) => ({
+  type: 'element',
+  tagName: 'a',
+  properties: { href },
+  children: [],
+});
+
+const makeActivitiesElement = ({
+  align,
+  children,
+}: {
+  align?: string;
+  children?: unknown[];
+} = {}) => ({
+  type: 'element',
+  tagName: 'div',
+  properties: align ? { align } : {},
+  children: children ?? [
+    makeAnchor('https://medium.com/@johndoe/0'),
+    makeAnchor('https://medium.com/@johndoe/1'),
+  ],
+});
+
+describe('FEATURE - activities importer', () => {
+  it('returns null when the element has no children', () => {
+    expect(
+      activitiesImporter(makeActivitiesElement({ children: [] }) as any)
+    ).toBeNull();
+  });
+
+  it('parses the username from the first anchor href', () => {
+    const result = activitiesImporter(
+      makeActivitiesElement({
+        children: [makeAnchor('https://medium.com/@janedoe/0')],
+      }) as any
+    );
+
+    expect(result?.props.content.username).toBe('janedoe');
+  });
+
+  it('sets content.limit to the number of anchor children', () => {
+    const result = activitiesImporter(
+      makeActivitiesElement({
+        children: [
+          makeAnchor('https://medium.com/@johndoe/0'),
+          makeAnchor('https://medium.com/@johndoe/1'),
+          makeAnchor('https://medium.com/@johndoe/2'),
+        ],
+      }) as any
+    );
+
+    expect(result?.props.content.limit).toBe(3);
+  });
+
+  it('reads align from the element properties when present', () => {
+    const result = activitiesImporter(
+      makeActivitiesElement({ align: 'left' }) as any
+    );
+
+    expect(result?.props.styles.align).toBe('left');
+  });
+
+  it('defaults align to center when the element has no align property', () => {
+    const result = activitiesImporter(makeActivitiesElement() as any);
+
+    expect(result?.props.styles.align).toBe('center');
+  });
+
+  it('returns a CanvasSection with type Sections.ACTIVITIES and a string id', () => {
+    const result = activitiesImporter(makeActivitiesElement() as any);
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe(Sections.ACTIVITIES);
+    expect(typeof result?.id).toBe('string');
+    expect(result?.id).not.toBe('');
+  });
+
+  it('does not mutate the shared defaultActivitiesSectionConfig', () => {
+    const snapshot = structuredClone(defaultActivitiesSectionConfig);
+
+    activitiesImporter(
+      makeActivitiesElement({
+        children: [makeAnchor('https://medium.com/@someone/0')],
+        align: 'right',
+      }) as any
+    );
+    activitiesImporter(
+      makeActivitiesElement({
+        children: [makeAnchor('https://medium.com/@another/0')],
+        align: 'left',
+      }) as any
+    );
+
+    expect(defaultActivitiesSectionConfig).toEqual(snapshot);
+  });
+});

--- a/src/features/activities/importer/test.ts
+++ b/src/features/activities/importer/test.ts
@@ -64,13 +64,13 @@ describe('FEATURE - activities importer', () => {
       makeActivitiesElement({ align: 'left' }) as any
     );
 
-    expect(result?.props.styles.align).toBe('left');
+    expect(result?.props?.styles?.align).toBe('left');
   });
 
   it('defaults align to center when the element has no align property', () => {
     const result = activitiesImporter(makeActivitiesElement() as any);
 
-    expect(result?.props.styles.align).toBe('center');
+    expect(result?.props?.styles?.align).toBe('center');
   });
 
   it('returns a CanvasSection with type Sections.ACTIVITIES and a string id', () => {

--- a/src/features/activities/index/test.tsx
+++ b/src/features/activities/index/test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { runInAction } from 'mobx';
+
+import { command } from '#/lib/command';
+import { extensionsStore } from '#/stores/extensions-store';
+import { PanelsEnum, Sections } from '#/types';
+
+import { ExtensionsHandle } from '#/components/handles/extensions';
+
+import { defaultActivitiesSectionConfig } from '../default-config';
+
+function resetExtensionsStore() {
+  runInAction(() => {
+    extensionsStore.extensions = {};
+    extensionsStore.registers = {};
+  });
+}
+
+describe('FEATURE - activities index (registration)', () => {
+  let unmount: () => void;
+  let disposeAdd: () => void;
+  const addHandler = vi.fn();
+
+  beforeAll(async () => {
+    resetExtensionsStore();
+    ({ unmount } = render(<ExtensionsHandle />));
+    disposeAdd = command.handle('canvas.section.add', addHandler);
+    await import('../index');
+  });
+
+  afterAll(() => {
+    unmount();
+    disposeAdd();
+    resetExtensionsStore();
+  });
+
+  it('registers the activities feature with id Sections.ACTIVITIES', () => {
+    expect(extensionsStore.registers[Sections.ACTIVITIES]).toBeDefined();
+    expect(extensionsStore.registers[Sections.ACTIVITIES].id).toBe(
+      Sections.ACTIVITIES
+    );
+  });
+
+  it('registers the NEW_SECTION presentation with icon and name', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.ACTIVITIES];
+
+    expect(newSection).toBeDefined();
+    expect(newSection.icon).toBe('activity');
+    expect(newSection.name).toBe('My activities');
+  });
+
+  it('registers the sections parser and defaultConfig', () => {
+    const register = extensionsStore.registers[Sections.ACTIVITIES];
+    const sections = register.presentation.sections as any;
+
+    expect(typeof sections.parser.readme).toBe('function');
+    expect(sections.defaultConfig).toEqual(defaultActivitiesSectionConfig);
+  });
+
+  it('onClick dispatches canvas.section.add with Sections.ACTIVITIES', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.ACTIVITIES];
+
+    newSection.onClick();
+
+    expect(addHandler).toHaveBeenCalledWith(Sections.ACTIVITIES);
+  });
+});

--- a/src/features/activities/index/test.tsx
+++ b/src/features/activities/index/test.tsx
@@ -43,8 +43,9 @@ describe('FEATURE - activities index (registration)', () => {
   });
 
   it('registers the NEW_SECTION presentation with icon and name', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.ACTIVITIES];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.ACTIVITIES
+    ] as any;
 
     expect(newSection).toBeDefined();
     expect(newSection.icon).toBe('activity');
@@ -60,8 +61,9 @@ describe('FEATURE - activities index (registration)', () => {
   });
 
   it('onClick dispatches canvas.section.add with Sections.ACTIVITIES', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.ACTIVITIES];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.ACTIVITIES
+    ] as any;
 
     newSection.onClick();
 

--- a/src/features/activities/panel/test.tsx
+++ b/src/features/activities/panel/test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { ActivitiesEditPanel } from '../panel';
+
+vi.mock('#/components/organisms/group-fields', () => ({
+  GroupFields: ({ id, label }: { id: number; label?: string }) => (
+    <div data-testid="group-fields" data-group-id={id} data-label={label} />
+  ),
+}));
+
+describe('FEATURE - ActivitiesEditPanel', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders one GroupFields per group defined in panel/fields', () => {
+    render(<ActivitiesEditPanel />);
+
+    const groups = screen.getAllByTestId('group-fields');
+
+    expect(groups).toHaveLength(3);
+  });
+
+  it('renders the Origin, Layout, and Medium options groups', () => {
+    render(<ActivitiesEditPanel />);
+
+    const labels = screen
+      .getAllByTestId('group-fields')
+      .map(el => el.getAttribute('data-label'));
+
+    expect(labels).toEqual([null, 'Layout', 'Medium options']);
+  });
+});

--- a/src/features/activities/parser/test.ts
+++ b/src/features/activities/parser/test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { Sections } from '#/types';
+
+import { activitiesSectionParser } from '../parser';
+
+vi.mock('#/utils/url', () => ({
+  url: {
+    getActivities: vi.fn((type: string) => `https://example.com/${type}`),
+  },
+}));
+
+describe('FEATURE - activities parser', () => {
+  it('emits a div with data-importer="activities" for medium type', () => {
+    const result = activitiesSectionParser({
+      content: { type: 'medium', limit: 2, username: 'johndoe' },
+      styles: { align: 'center' },
+    });
+
+    expect(result).toContain(`data-importer="${Sections.ACTIVITIES}"`);
+    expect(result).toContain('<div');
+    expect(result).toContain('</div>');
+  });
+
+  it('emits one <a><img></a> per post based on content.limit', () => {
+    const result = activitiesSectionParser({
+      content: { type: 'medium', limit: 3, username: 'johndoe' },
+      styles: { align: 'center' },
+    });
+
+    const anchorCount = (result.match(/<a /g) || []).length;
+    const imgCount = (result.match(/<img /g) || []).length;
+
+    expect(anchorCount).toBe(3);
+    expect(imgCount).toBe(3);
+  });
+
+  it('builds each post src as baseUrl/@username/index', () => {
+    const result = activitiesSectionParser({
+      content: { type: 'medium', limit: 2, username: 'johndoe' },
+      styles: { align: 'center' },
+    });
+
+    expect(result).toContain('href="https://example.com/medium/@johndoe/0"');
+    expect(result).toContain('href="https://example.com/medium/@johndoe/1"');
+    expect(result).toContain('src="https://example.com/medium/@johndoe/0"');
+    expect(result).toContain('src="https://example.com/medium/@johndoe/1"');
+  });
+
+  it('uses alt text "Medium post N" for each post', () => {
+    const result = activitiesSectionParser({
+      content: { type: 'medium', limit: 2, username: 'johndoe' },
+      styles: { align: 'center' },
+    });
+
+    expect(result).toContain('alt="Medium post 1"');
+    expect(result).toContain('alt="Medium post 2"');
+  });
+
+  it('defaults limit to 3 when not provided for medium', () => {
+    const result = activitiesSectionParser({
+      content: { type: 'medium', username: 'johndoe' },
+      styles: { align: 'center' },
+    });
+
+    const anchorCount = (result.match(/<a /g) || []).length;
+
+    expect(anchorCount).toBe(3);
+  });
+
+  it('includes the align attribute on the wrapper div for medium', () => {
+    const result = activitiesSectionParser({
+      content: { type: 'medium', limit: 1, username: 'johndoe' },
+      styles: { align: 'right' },
+    });
+
+    expect(result).toContain('align="right"');
+  });
+
+  it('falls back to default handler for unknown types', () => {
+    const result = activitiesSectionParser({
+      content: { type: 'unknown-type' as any },
+      styles: { align: 'left' },
+    });
+
+    expect(result).toContain('align="left"');
+    expect(result).toContain('<img');
+    expect(result).toContain('src="https://example.com/unknown-type"');
+    expect(result).toContain('alt="Layout with last unknown-type posts"');
+  });
+
+  it('does not include data-importer on the default handler path', () => {
+    const result = activitiesSectionParser({
+      content: { type: 'unknown-type' as any },
+      styles: { align: 'left' },
+    });
+
+    expect(result).not.toContain('data-importer');
+  });
+});

--- a/src/features/activities/section/test.tsx
+++ b/src/features/activities/section/test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+import { ActivitiesSection } from '../section';
+
+vi.mock('#/utils/url', () => ({
+  url: {
+    getActivities: vi.fn((type: string) => `https://example.com/${type}`),
+  },
+}));
+
+describe('FEATURE - ActivitiesSection', () => {
+  it('renders the wrapper div with flex class and justify-content from align', () => {
+    const { container } = render(
+      <ActivitiesSection
+        id="section-1"
+        content={{ type: 'medium', limit: 1, username: 'johndoe' }}
+        styles={{ align: 'center' }}
+      />
+    );
+
+    const wrapper = container.querySelector('.flex');
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.getAttribute('style')).toContain('justify-content: center');
+  });
+
+  it('renders one anchor and one img per post for medium type', () => {
+    const { container } = render(
+      <ActivitiesSection
+        id="section-1"
+        content={{ type: 'medium', limit: 2, username: 'johndoe' }}
+        styles={{ align: 'center' }}
+      />
+    );
+
+    expect(container.querySelectorAll('a')).toHaveLength(2);
+    expect(container.querySelectorAll('img')).toHaveLength(2);
+  });
+
+  it('renders a single img for the default (non-medium) path', () => {
+    const { container } = render(
+      <ActivitiesSection
+        id="section-1"
+        content={{ type: 'unknown-type' as any }}
+        styles={{ align: 'left' }}
+      />
+    );
+
+    expect(container.querySelectorAll('a')).toHaveLength(0);
+    expect(container.querySelectorAll('img')).toHaveLength(1);
+  });
+});

--- a/src/features/music/importer/test.ts
+++ b/src/features/music/importer/test.ts
@@ -44,7 +44,9 @@ describe('FEATURE - music importer', () => {
   it('parses a "currently" section from an img child', () => {
     const result = musicImporter(
       makeMusicDiv([
-        makeImg('https://example.com/widget?theme=dark&spin=true&scan=false&rainbow=true'),
+        makeImg(
+          'https://example.com/widget?theme=dark&spin=true&scan=false&rainbow=true'
+        ),
       ]) as any
     );
 

--- a/src/features/music/importer/test.ts
+++ b/src/features/music/importer/test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+
+import { Sections } from '#/types';
+import { defaultMusicSectionConfig } from '../default-config';
+
+import { musicImporter } from '../importer';
+
+const makeImg = (src: string) => ({
+  type: 'element',
+  tagName: 'img',
+  properties: { src },
+  children: [],
+});
+
+const makeAnchorWithImg = (href: string, imgSrc: string) => ({
+  type: 'element',
+  tagName: 'a',
+  properties: { href },
+  children: [makeImg(imgSrc)],
+});
+
+const makeMusicDiv = (children: unknown[], align?: string) => ({
+  type: 'element',
+  tagName: 'div',
+  properties: align ? { align } : {},
+  children,
+});
+
+describe('FEATURE - music importer', () => {
+  it('returns null when the element has no children', () => {
+    expect(musicImporter(makeMusicDiv([]) as any)).toBeNull();
+  });
+
+  it('returns null when the first element child is neither img nor a', () => {
+    expect(
+      musicImporter(
+        makeMusicDiv([
+          { type: 'element', tagName: 'span', properties: {}, children: [] },
+        ]) as any
+      )
+    ).toBeNull();
+  });
+
+  it('parses a "currently" section from an img child', () => {
+    const result = musicImporter(
+      makeMusicDiv([
+        makeImg('https://example.com/widget?theme=dark&spin=true&scan=false&rainbow=true'),
+      ]) as any
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe(Sections.MUSIC);
+    expect(result?.props.content.type).toBe('currently');
+    expect(result?.props.content.currently.itstommi.url).toBe(
+      'https://example.com/widget'
+    );
+    expect(result?.props.content.currently.itstommi.props.theme).toBe('dark');
+    expect(result?.props.content.currently.itstommi.props.spin).toBe(true);
+    expect(result?.props.content.currently.itstommi.props.scan).toBe(false);
+    expect(result?.props.content.currently.itstommi.props.rainbow).toBe(true);
+  });
+
+  it('parses a "recently" section from an anchor child', () => {
+    const result = musicImporter(
+      makeMusicDiv([
+        makeAnchorWithImg(
+          'https://spotify.com/user/johndoe',
+          'https://img.example.com/recent?count=10&unique=true'
+        ),
+      ]) as any
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe(Sections.MUSIC);
+    expect(result?.props.content.type).toBe('recently');
+    expect(result?.props.content.recently.user).toBe('johndoe');
+    expect(result?.props.content.recently.count).toBe('10');
+    expect(result?.props.content.recently.unique).toBe(true);
+  });
+
+  it('reads align from the element properties when present', () => {
+    const result = musicImporter(
+      makeMusicDiv(
+        [makeImg('https://example.com/widget?theme=dark')],
+        'left'
+      ) as any
+    );
+
+    expect(result?.props.styles.align).toBe('left');
+  });
+
+  it('defaults align to center when the element has no align property', () => {
+    const result = musicImporter(
+      makeMusicDiv([makeImg('https://example.com/widget?theme=dark')]) as any
+    );
+
+    expect(result?.props.styles.align).toBe('center');
+  });
+
+  it('returns a CanvasSection with a string id', () => {
+    const result = musicImporter(
+      makeMusicDiv([makeImg('https://example.com/widget?theme=dark')]) as any
+    );
+
+    expect(typeof result?.id).toBe('string');
+    expect(result?.id).not.toBe('');
+  });
+
+  it('does not mutate the shared defaultMusicSectionConfig', () => {
+    const snapshot = structuredClone(defaultMusicSectionConfig);
+
+    musicImporter(
+      makeMusicDiv([
+        makeImg('https://example.com/widget?theme=light&spin=true'),
+      ]) as any
+    );
+    musicImporter(
+      makeMusicDiv([
+        makeAnchorWithImg(
+          'https://spotify.com/user/someone',
+          'https://img.example.com/recent?count=3'
+        ),
+      ]) as any
+    );
+
+    expect(defaultMusicSectionConfig).toEqual(snapshot);
+  });
+});

--- a/src/features/music/importer/test.ts
+++ b/src/features/music/importer/test.ts
@@ -88,7 +88,7 @@ describe('FEATURE - music importer', () => {
       ) as any
     );
 
-    expect(result?.props.styles.align).toBe('left');
+    expect(result?.props?.styles?.align).toBe('left');
   });
 
   it('defaults align to center when the element has no align property', () => {
@@ -96,7 +96,7 @@ describe('FEATURE - music importer', () => {
       makeMusicDiv([makeImg('https://example.com/widget?theme=dark')]) as any
     );
 
-    expect(result?.props.styles.align).toBe('center');
+    expect(result?.props?.styles?.align).toBe('center');
   });
 
   it('returns a CanvasSection with a string id', () => {

--- a/src/features/music/index/test.tsx
+++ b/src/features/music/index/test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { runInAction } from 'mobx';
+
+import { command } from '#/lib/command';
+import { extensionsStore } from '#/stores/extensions-store';
+import { PanelsEnum, Sections } from '#/types';
+
+import { ExtensionsHandle } from '#/components/handles/extensions';
+
+import { defaultMusicSectionConfig } from '../default-config';
+
+function resetExtensionsStore() {
+  runInAction(() => {
+    extensionsStore.extensions = {};
+    extensionsStore.registers = {};
+  });
+}
+
+describe('FEATURE - music index (registration)', () => {
+  let unmount: () => void;
+  let disposeAdd: () => void;
+  const addHandler = vi.fn();
+
+  beforeAll(async () => {
+    resetExtensionsStore();
+    ({ unmount } = render(<ExtensionsHandle />));
+    disposeAdd = command.handle('canvas.section.add', addHandler);
+    await import('../index');
+  });
+
+  afterAll(() => {
+    unmount();
+    disposeAdd();
+    resetExtensionsStore();
+  });
+
+  it('registers the music feature with id Sections.MUSIC', () => {
+    expect(extensionsStore.registers[Sections.MUSIC]).toBeDefined();
+    expect(extensionsStore.registers[Sections.MUSIC].id).toBe(Sections.MUSIC);
+  });
+
+  it('registers the NEW_SECTION presentation with icon and name', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.MUSIC];
+
+    expect(newSection).toBeDefined();
+    expect(newSection.icon).toBe('music');
+    expect(newSection.name).toBe('Music');
+  });
+
+  it('registers the sections parser and defaultConfig', () => {
+    const register = extensionsStore.registers[Sections.MUSIC];
+    const sections = register.presentation.sections as any;
+
+    expect(typeof sections.parser.readme).toBe('function');
+    expect(sections.defaultConfig).toEqual(defaultMusicSectionConfig);
+  });
+
+  it('onClick dispatches canvas.section.add with Sections.MUSIC', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.MUSIC];
+
+    newSection.onClick();
+
+    expect(addHandler).toHaveBeenCalledWith(Sections.MUSIC);
+  });
+});

--- a/src/features/music/index/test.tsx
+++ b/src/features/music/index/test.tsx
@@ -41,8 +41,9 @@ describe('FEATURE - music index (registration)', () => {
   });
 
   it('registers the NEW_SECTION presentation with icon and name', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.MUSIC];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.MUSIC
+    ] as any;
 
     expect(newSection).toBeDefined();
     expect(newSection.icon).toBe('music');
@@ -58,8 +59,9 @@ describe('FEATURE - music index (registration)', () => {
   });
 
   it('onClick dispatches canvas.section.add with Sections.MUSIC', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.MUSIC];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.MUSIC
+    ] as any;
 
     newSection.onClick();
 

--- a/src/features/music/panel/test.tsx
+++ b/src/features/music/panel/test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { MusicEditPanel } from '../panel';
+
+vi.mock('#/components/organisms/group-fields', () => ({
+  GroupFields: ({ id, label }: { id: number; label?: string }) => (
+    <div data-testid="group-fields" data-group-id={id} data-label={label} />
+  ),
+}));
+
+vi.mock('#/components/organisms/panel', () => {
+  const Panel = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="panel">{children}</div>
+  );
+  Panel.Scrollable = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="panel-scrollable">{children}</div>
+  );
+  return { Panel };
+});
+
+vi.mock('#/hooks', () => ({
+  useCanvas: () => ({
+    $currentSection: { props: { content: { type: 'recently' } } },
+  }),
+}));
+
+vi.mock('#/utils/object', () => ({
+  object: {
+    deep: {
+      get: vi.fn((obj: any, path: string) => {
+        if (path === 'props.content.type') return 'recently';
+        return undefined;
+      }),
+    },
+  },
+}));
+
+vi.mock('./views', () => ({
+  views: {
+    recently: () => <div data-testid="view-recently">Recently View</div>,
+    currently: () => <div data-testid="view-currently">Currently View</div>,
+  },
+}));
+
+describe('FEATURE - MusicEditPanel', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders groups from panel/fields wrapped in Panel.Scrollable', () => {
+    render(<MusicEditPanel />);
+
+    expect(screen.getAllByTestId('panel-scrollable')).toHaveLength(1);
+    expect(screen.getAllByTestId('group-fields')).toHaveLength(2);
+  });
+
+  it('renders the Type and Layout groups', () => {
+    render(<MusicEditPanel />);
+
+    const labels = screen
+      .getAllByTestId('group-fields')
+      .map(el => el.getAttribute('data-label'));
+
+    expect(labels).toEqual([null, 'Layout']);
+  });
+
+  it('renders the active view based on content.type', () => {
+    render(<MusicEditPanel />);
+
+    expect(screen.getByTestId('view-recently')).not.toBeNull();
+  });
+});

--- a/src/features/music/panel/test.tsx
+++ b/src/features/music/panel/test.tsx
@@ -28,7 +28,7 @@ vi.mock('#/hooks', () => ({
 vi.mock('#/utils/object', () => ({
   object: {
     deep: {
-      get: vi.fn((obj: any, path: string) => {
+      get: vi.fn((_obj: any, path: string) => {
         if (path === 'props.content.type') return 'recently';
         return undefined;
       }),

--- a/src/features/music/parser/test.ts
+++ b/src/features/music/parser/test.ts
@@ -21,7 +21,11 @@ vi.mock('#/utils/url', () => ({
 describe('FEATURE - music parser', () => {
   it('emits a div with data-importer="music"', () => {
     const result = musicSectionParser({
-      content: { type: 'recently', recently: { user: 'johndoe' }, currently: {} } as any,
+      content: {
+        type: 'recently',
+        recently: { user: 'johndoe' },
+        currently: {},
+      } as any,
       styles: { align: 'center' },
     });
 
@@ -32,7 +36,11 @@ describe('FEATURE - music parser', () => {
 
   it('includes the align attribute on the wrapper div', () => {
     const result = musicSectionParser({
-      content: { type: 'recently', recently: { user: 'johndoe' }, currently: {} } as any,
+      content: {
+        type: 'recently',
+        recently: { user: 'johndoe' },
+        currently: {},
+      } as any,
       styles: { align: 'right' },
     });
 
@@ -41,7 +49,11 @@ describe('FEATURE - music parser', () => {
 
   it('wraps the img in an anchor when spotifyAccountUrl is present (recently)', () => {
     const result = musicSectionParser({
-      content: { type: 'recently', recently: { user: 'johndoe' }, currently: {} } as any,
+      content: {
+        type: 'recently',
+        recently: { user: 'johndoe' },
+        currently: {},
+      } as any,
       styles: { align: 'center' },
     });
 
@@ -62,7 +74,11 @@ describe('FEATURE - music parser', () => {
 
   it('uses the correct alt text for recently type', () => {
     const result = musicSectionParser({
-      content: { type: 'recently', recently: { user: 'johndoe' }, currently: {} } as any,
+      content: {
+        type: 'recently',
+        recently: { user: 'johndoe' },
+        currently: {},
+      } as any,
       styles: { align: 'center' },
     });
 

--- a/src/features/music/parser/test.ts
+++ b/src/features/music/parser/test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { Sections } from '#/types';
+
+import { musicSectionParser } from '../parser';
+
+vi.mock('#/utils/url', () => ({
+  url: {
+    getMusic: vi.fn((type: string) => {
+      if (type === 'recently') {
+        return {
+          spotifyAccountUrl: 'https://spotify.com/user/johndoe',
+          imageUrl: 'https://img.example.com/recently',
+        };
+      }
+      return { imageUrl: 'https://img.example.com/currently' };
+    }),
+  },
+}));
+
+describe('FEATURE - music parser', () => {
+  it('emits a div with data-importer="music"', () => {
+    const result = musicSectionParser({
+      content: { type: 'recently', recently: { user: 'johndoe' }, currently: {} } as any,
+      styles: { align: 'center' },
+    });
+
+    expect(result).toContain(`data-importer="${Sections.MUSIC}"`);
+    expect(result).toContain('<div');
+    expect(result).toContain('</div>');
+  });
+
+  it('includes the align attribute on the wrapper div', () => {
+    const result = musicSectionParser({
+      content: { type: 'recently', recently: { user: 'johndoe' }, currently: {} } as any,
+      styles: { align: 'right' },
+    });
+
+    expect(result).toContain('align="right"');
+  });
+
+  it('wraps the img in an anchor when spotifyAccountUrl is present (recently)', () => {
+    const result = musicSectionParser({
+      content: { type: 'recently', recently: { user: 'johndoe' }, currently: {} } as any,
+      styles: { align: 'center' },
+    });
+
+    expect(result).toContain('<a href="https://spotify.com/user/johndoe">');
+    expect(result).toContain('</a>');
+    expect(result).toContain('src="https://img.example.com/recently"');
+  });
+
+  it('does not wrap the img in an anchor when spotifyAccountUrl is absent (currently)', () => {
+    const result = musicSectionParser({
+      content: { type: 'currently', recently: {}, currently: {} } as any,
+      styles: { align: 'center' },
+    });
+
+    expect(result).not.toContain('<a ');
+    expect(result).toContain('src="https://img.example.com/currently"');
+  });
+
+  it('uses the correct alt text for recently type', () => {
+    const result = musicSectionParser({
+      content: { type: 'recently', recently: { user: 'johndoe' }, currently: {} } as any,
+      styles: { align: 'center' },
+    });
+
+    expect(result).toContain('alt="Spotify recently played"');
+  });
+
+  it('uses the correct alt text for currently type', () => {
+    const result = musicSectionParser({
+      content: { type: 'currently', recently: {}, currently: {} } as any,
+      styles: { align: 'center' },
+    });
+
+    expect(result).toContain('alt="Widget with the current Spotify song"');
+  });
+});

--- a/src/features/music/section/test.tsx
+++ b/src/features/music/section/test.tsx
@@ -81,7 +81,9 @@ describe('FEATURE - MusicSection', () => {
     const anchor = container.querySelector('a');
 
     expect(anchor).not.toBeNull();
-    expect(anchor?.getAttribute('href')).toBe('https://spotify.com/user/johndoe');
+    expect(anchor?.getAttribute('href')).toBe(
+      'https://spotify.com/user/johndoe'
+    );
   });
 
   it('does not wrap the img in an anchor when spotifyAccountUrl is absent (currently)', () => {

--- a/src/features/music/section/test.tsx
+++ b/src/features/music/section/test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import { MusicSection } from '../section';
+
+vi.mock('#/utils/url', () => ({
+  url: {
+    getMusic: vi.fn((type: string) => {
+      if (type === 'recently') {
+        return {
+          spotifyAccountUrl: 'https://spotify.com/user/johndoe',
+          imageUrl: 'https://img.example.com/recently',
+        };
+      }
+      return { imageUrl: 'https://img.example.com/currently' };
+    }),
+  },
+}));
+
+const messages = {
+  ui: {
+    alts: {
+      'spotify-recently': 'Spotify recently played',
+      'spotify-currently': 'Widget with the current Spotify song',
+    },
+  },
+};
+
+function renderWithProvider(ui: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('FEATURE - MusicSection', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the wrapper div with flex class and justify-content from align', () => {
+    const { container } = renderWithProvider(
+      <MusicSection
+        id="section-1"
+        content={{ type: 'recently', recently: {}, currently: {} } as any}
+        styles={{ align: 'center' }}
+      />
+    );
+
+    const wrapper = container.querySelector('.flex');
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.getAttribute('style')).toContain('justify-content: center');
+  });
+
+  it('renders an img with src from url.getMusic for recently', () => {
+    const { container } = renderWithProvider(
+      <MusicSection
+        id="section-1"
+        content={{ type: 'recently', recently: {}, currently: {} } as any}
+        styles={{ align: 'center' }}
+      />
+    );
+
+    const img = container.querySelector('img');
+
+    expect(img?.getAttribute('src')).toBe('https://img.example.com/recently');
+  });
+
+  it('wraps the img in an anchor when spotifyAccountUrl is present (recently)', () => {
+    const { container } = renderWithProvider(
+      <MusicSection
+        id="section-1"
+        content={{ type: 'recently', recently: {}, currently: {} } as any}
+        styles={{ align: 'center' }}
+      />
+    );
+
+    const anchor = container.querySelector('a');
+
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe('https://spotify.com/user/johndoe');
+  });
+
+  it('does not wrap the img in an anchor when spotifyAccountUrl is absent (currently)', () => {
+    const { container } = renderWithProvider(
+      <MusicSection
+        id="section-1"
+        content={{ type: 'currently', recently: {}, currently: {} } as any}
+        styles={{ align: 'center' }}
+      />
+    );
+
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://img.example.com/currently'
+    );
+  });
+
+  it('renders the img with alt from translations', () => {
+    const { container } = renderWithProvider(
+      <MusicSection
+        id="section-1"
+        content={{ type: 'recently', recently: {}, currently: {} } as any}
+        styles={{ align: 'center' }}
+      />
+    );
+
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe(
+      'Spotify recently played'
+    );
+  });
+});

--- a/src/features/pacman/importer/test.ts
+++ b/src/features/pacman/importer/test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+
+import { Sections } from '#/types';
+import { defaultPacmanSectionConfig } from '../default-config';
+
+import { pacmanImporter } from '../importer';
+
+const makeImg = (src?: string) => ({
+  type: 'element',
+  tagName: 'img',
+  properties: src ? { src } : {},
+  children: [],
+});
+
+const makePicture = (children?: unknown[]) => ({
+  type: 'element',
+  tagName: 'picture',
+  properties: {},
+  children: children ?? [
+    makeImg(
+      'https://raw.githubusercontent.com/octocat/octocat/pacman-output/pacman-contribution-graph.svg?game=pacman'
+    ),
+  ],
+});
+
+describe('FEATURE - pacman importer', () => {
+  it('returns null when no img child with src is found', () => {
+    expect(
+      pacmanImporter(makePicture([makeImg()]) as any)
+    ).toBeNull();
+  });
+
+  it('returns null when the picture has no children', () => {
+    expect(pacmanImporter(makePicture([]) as any)).toBeNull();
+  });
+
+  it('returns a CanvasSection with type Sections.PACMAN and a string id', () => {
+    const result = pacmanImporter(makePicture() as any);
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe(Sections.PACMAN);
+    expect(typeof result?.id).toBe('string');
+    expect(result?.id).not.toBe('');
+  });
+
+  it('extracts game from the img src query params', () => {
+    const result = pacmanImporter(
+      makePicture([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/pacman-output/breakout-contribution-graph.svg?game=breakout'
+        ),
+      ]) as any
+    );
+
+    expect(result?.props.game).toBe('breakout');
+  });
+
+  it('keeps the default game when query param is absent', () => {
+    const result = pacmanImporter(
+      makePicture([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/pacman-output/pacman-contribution-graph.svg'
+        ),
+      ]) as any
+    );
+
+    expect(result?.props.game).toBe('pacman');
+  });
+
+  it('does not mutate the shared defaultPacmanSectionConfig', () => {
+    const snapshot = structuredClone(defaultPacmanSectionConfig);
+
+    pacmanImporter(
+      makePicture([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/pacman-output/breakout-contribution-graph.svg?game=breakout'
+        ),
+      ]) as any
+    );
+
+    expect(defaultPacmanSectionConfig).toEqual(snapshot);
+  });
+});

--- a/src/features/pacman/importer/test.ts
+++ b/src/features/pacman/importer/test.ts
@@ -25,9 +25,7 @@ const makePicture = (children?: unknown[]) => ({
 
 describe('FEATURE - pacman importer', () => {
   it('returns null when no img child with src is found', () => {
-    expect(
-      pacmanImporter(makePicture([makeImg()]) as any)
-    ).toBeNull();
+    expect(pacmanImporter(makePicture([makeImg()]) as any)).toBeNull();
   });
 
   it('returns null when the picture has no children', () => {

--- a/src/features/pacman/index/test.tsx
+++ b/src/features/pacman/index/test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { runInAction } from 'mobx';
+
+import { command } from '#/lib/command';
+import { extensionsStore } from '#/stores/extensions-store';
+import { PanelsEnum, Sections } from '#/types';
+
+import { ExtensionsHandle } from '#/components/handles/extensions';
+
+import { defaultPacmanSectionConfig } from '../default-config';
+
+function resetExtensionsStore() {
+  runInAction(() => {
+    extensionsStore.extensions = {};
+    extensionsStore.registers = {};
+  });
+}
+
+describe('FEATURE - pacman index (registration)', () => {
+  let unmount: () => void;
+  let disposeAdd: () => void;
+  const addHandler = vi.fn();
+
+  beforeAll(async () => {
+    resetExtensionsStore();
+    ({ unmount } = render(<ExtensionsHandle />));
+    disposeAdd = command.handle('canvas.section.add', addHandler);
+    await import('../index');
+  });
+
+  afterAll(() => {
+    unmount();
+    disposeAdd();
+    resetExtensionsStore();
+  });
+
+  it('registers the pacman feature with id Sections.PACMAN', () => {
+    expect(extensionsStore.registers[Sections.PACMAN]).toBeDefined();
+    expect(extensionsStore.registers[Sections.PACMAN].id).toBe(Sections.PACMAN);
+  });
+
+  it('registers the NEW_SECTION presentation with icon and name', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.PACMAN];
+
+    expect(newSection).toBeDefined();
+    expect(newSection.icon).toBe('ghost');
+    expect(newSection.name).toBe('Arcade games');
+  });
+
+  it('registers the sections readme and workflow parsers and defaultConfig', () => {
+    const register = extensionsStore.registers[Sections.PACMAN];
+    const sections = register.presentation.sections as any;
+
+    expect(typeof sections.parser.readme).toBe('function');
+    expect(typeof sections.parser.workflow).toBe('function');
+    expect(sections.defaultConfig).toEqual(defaultPacmanSectionConfig);
+  });
+
+  it('onClick dispatches canvas.section.add with Sections.PACMAN', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.PACMAN];
+
+    newSection.onClick();
+
+    expect(addHandler).toHaveBeenCalledWith(Sections.PACMAN);
+  });
+});

--- a/src/features/pacman/index/test.tsx
+++ b/src/features/pacman/index/test.tsx
@@ -41,8 +41,9 @@ describe('FEATURE - pacman index (registration)', () => {
   });
 
   it('registers the NEW_SECTION presentation with icon and name', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.PACMAN];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.PACMAN
+    ] as any;
 
     expect(newSection).toBeDefined();
     expect(newSection.icon).toBe('ghost');
@@ -59,8 +60,9 @@ describe('FEATURE - pacman index (registration)', () => {
   });
 
   it('onClick dispatches canvas.section.add with Sections.PACMAN', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.PACMAN];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.PACMAN
+    ] as any;
 
     newSection.onClick();
 

--- a/src/features/pacman/panel/test.tsx
+++ b/src/features/pacman/panel/test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { PacmanPanel } from '../panel';
+
+vi.mock('#/components/organisms/group-fields', () => ({
+  GroupFields: ({ id, label }: { id: number; label?: string }) => (
+    <div data-testid="group-fields" data-group-id={id} data-label={label} />
+  ),
+}));
+
+describe('FEATURE - PacmanPanel', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders one GroupFields per group defined in panel/fields', () => {
+    render(<PacmanPanel />);
+
+    const groups = screen.getAllByTestId('group-fields');
+
+    expect(groups).toHaveLength(1);
+  });
+
+  it('renders the single group with an empty label', () => {
+    render(<PacmanPanel />);
+
+    const group = screen.getByTestId('group-fields');
+
+    expect(group.getAttribute('data-group-id')).toBe('1');
+    expect(group.getAttribute('data-label')).toBe('');
+  });
+});

--- a/src/features/pacman/parser/test.ts
+++ b/src/features/pacman/parser/test.ts
@@ -16,7 +16,9 @@ vi.mock('#/utils/object', () => ({
 
 describe('FEATURE - pacman parser', () => {
   it('emits a picture with data-importer="pacman"', () => {
-    const result = pacmanSectionParser({}, { user: { github: 'octocat' } } as any);
+    const result = pacmanSectionParser({}, {
+      user: { github: 'octocat' },
+    } as any);
 
     expect(result).toContain(`data-importer="${Sections.PACMAN}"`);
     expect(result).toContain('<picture');
@@ -24,7 +26,9 @@ describe('FEATURE - pacman parser', () => {
   });
 
   it('builds source and img URLs from settings.user.github', () => {
-    const result = pacmanSectionParser({}, { user: { github: 'octocat' } } as any);
+    const result = pacmanSectionParser({}, {
+      user: { github: 'octocat' },
+    } as any);
 
     expect(result).toContain(
       'srcset="https://raw.githubusercontent.com/octocat/octocat/pacman-output/pacman-contribution-graph-dark.svg?game=pacman"'
@@ -35,30 +39,35 @@ describe('FEATURE - pacman parser', () => {
   });
 
   it('defaults game to pacman when config.game is absent', () => {
-    const result = pacmanSectionParser({}, { user: { github: 'octocat' } } as any);
+    const result = pacmanSectionParser({}, {
+      user: { github: 'octocat' },
+    } as any);
 
     expect(result).toContain('pacman-contribution-graph');
   });
 
   it('uses the provided game when config.game is set', () => {
-    const result = pacmanSectionParser(
-      { game: 'breakout' },
-      { user: { github: 'octocat' } } as any
-    );
+    const result = pacmanSectionParser({ game: 'breakout' }, {
+      user: { github: 'octocat' },
+    } as any);
 
     expect(result).toContain('breakout-contribution-graph');
     expect(result).toContain('game=breakout');
   });
 
   it('includes dark and light prefers-color-scheme sources', () => {
-    const result = pacmanSectionParser({}, { user: { github: 'octocat' } } as any);
+    const result = pacmanSectionParser({}, {
+      user: { github: 'octocat' },
+    } as any);
 
     expect(result).toContain('media="(prefers-color-scheme: dark)"');
     expect(result).toContain('media="(prefers-color-scheme: light)"');
   });
 
   it('uses "pacman contribution graph" as img alt', () => {
-    const result = pacmanSectionParser({}, { user: { github: 'octocat' } } as any);
+    const result = pacmanSectionParser({}, {
+      user: { github: 'octocat' },
+    } as any);
 
     expect(result).toContain('alt="pacman contribution graph"');
   });

--- a/src/features/pacman/parser/test.ts
+++ b/src/features/pacman/parser/test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { Sections } from '#/types';
+
+import { pacmanSectionParser, pacmanWorkflowParser } from '../parser';
+
+vi.mock('#/utils/object', () => ({
+  object: {
+    toQueryParams: vi.fn((params: Record<string, string>) =>
+      Object.entries(params)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('&')
+    ),
+  },
+}));
+
+describe('FEATURE - pacman parser', () => {
+  it('emits a picture with data-importer="pacman"', () => {
+    const result = pacmanSectionParser({}, { user: { github: 'octocat' } } as any);
+
+    expect(result).toContain(`data-importer="${Sections.PACMAN}"`);
+    expect(result).toContain('<picture');
+    expect(result).toContain('</picture>');
+  });
+
+  it('builds source and img URLs from settings.user.github', () => {
+    const result = pacmanSectionParser({}, { user: { github: 'octocat' } } as any);
+
+    expect(result).toContain(
+      'srcset="https://raw.githubusercontent.com/octocat/octocat/pacman-output/pacman-contribution-graph-dark.svg?game=pacman"'
+    );
+    expect(result).toContain(
+      'src="https://raw.githubusercontent.com/octocat/octocat/pacman-output/pacman-contribution-graph.svg?game=pacman"'
+    );
+  });
+
+  it('defaults game to pacman when config.game is absent', () => {
+    const result = pacmanSectionParser({}, { user: { github: 'octocat' } } as any);
+
+    expect(result).toContain('pacman-contribution-graph');
+  });
+
+  it('uses the provided game when config.game is set', () => {
+    const result = pacmanSectionParser(
+      { game: 'breakout' },
+      { user: { github: 'octocat' } } as any
+    );
+
+    expect(result).toContain('breakout-contribution-graph');
+    expect(result).toContain('game=breakout');
+  });
+
+  it('includes dark and light prefers-color-scheme sources', () => {
+    const result = pacmanSectionParser({}, { user: { github: 'octocat' } } as any);
+
+    expect(result).toContain('media="(prefers-color-scheme: dark)"');
+    expect(result).toContain('media="(prefers-color-scheme: light)"');
+  });
+
+  it('uses "pacman contribution graph" as img alt', () => {
+    const result = pacmanSectionParser({}, { user: { github: 'octocat' } } as any);
+
+    expect(result).toContain('alt="pacman contribution graph"');
+  });
+
+  it('pacmanWorkflowParser returns an object with file and content', () => {
+    const result = pacmanWorkflowParser({});
+
+    expect(result.file).toBe('arcade.yml');
+    expect(typeof result.content).toBe('string');
+  });
+
+  it('pacmanWorkflowParser content contains the workflow name', () => {
+    const result = pacmanWorkflowParser({});
+
+    expect(result.content).toContain('name: Generate arcade animation');
+  });
+
+  it('pacmanWorkflowParser content contains the game value', () => {
+    const result = pacmanWorkflowParser({ game: 'galaga' });
+
+    expect(result.content).toContain("games: 'galaga'");
+  });
+
+  it('pacmanWorkflowParser defaults game to pacman', () => {
+    const result = pacmanWorkflowParser({});
+
+    expect(result.content).toContain("games: 'pacman'");
+  });
+});

--- a/src/features/pacman/section/test.tsx
+++ b/src/features/pacman/section/test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import { PacmanSection } from '../section';
+
+vi.mock('#/components/organisms/sections/guard', () => ({
+  GuardSection: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="guard-section">{children}</div>
+  ),
+}));
+
+const messages = { ui: { alts: { pacman: 'Pacman contribution graph' } } };
+
+function renderWithProvider(ui: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('FEATURE - PacmanSection', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('wraps content in GuardSection', () => {
+    const { getByTestId } = renderWithProvider(
+      <PacmanSection id="section-1" />
+    );
+
+    expect(getByTestId('guard-section')).not.toBeNull();
+  });
+
+  it('renders an img with the pacman svg src by default', () => {
+    const { container } = renderWithProvider(
+      <PacmanSection id="section-1" />
+    );
+
+    const img = container.querySelector('img');
+
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toContain('pacman.svg');
+  });
+
+  it('renders the breakout svg when game is "breakout"', () => {
+    const { container } = renderWithProvider(
+      <PacmanSection id="section-1" game="breakout" />
+    );
+
+    expect(container.querySelector('img')?.getAttribute('src')).toContain(
+      'breakout.svg'
+    );
+  });
+
+  it('falls back to pacman svg for an unknown game', () => {
+    const { container } = renderWithProvider(
+      <PacmanSection id="section-1" game="unknown-game" />
+    );
+
+    expect(container.querySelector('img')?.getAttribute('src')).toContain(
+      'pacman.svg'
+    );
+  });
+
+  it('renders the img with w-full class', () => {
+    const { container } = renderWithProvider(
+      <PacmanSection id="section-1" />
+    );
+
+    expect(container.querySelector('img')?.className).toContain('w-full');
+  });
+});

--- a/src/features/pacman/section/test.tsx
+++ b/src/features/pacman/section/test.tsx
@@ -34,9 +34,7 @@ describe('FEATURE - PacmanSection', () => {
   });
 
   it('renders an img with the pacman svg src by default', () => {
-    const { container } = renderWithProvider(
-      <PacmanSection id="section-1" />
-    );
+    const { container } = renderWithProvider(<PacmanSection id="section-1" />);
 
     const img = container.querySelector('img');
 
@@ -65,9 +63,7 @@ describe('FEATURE - PacmanSection', () => {
   });
 
   it('renders the img with w-full class', () => {
-    const { container } = renderWithProvider(
-      <PacmanSection id="section-1" />
-    );
+    const { container } = renderWithProvider(<PacmanSection id="section-1" />);
 
     expect(container.querySelector('img')?.className).toContain('w-full');
   });

--- a/src/features/snake/importer/test.ts
+++ b/src/features/snake/importer/test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+
+import { Sections } from '#/types';
+import { defaultSnakeSectionConfig } from '../default-config';
+
+import { snakeImporter } from '../importer';
+
+const makeElement = () => ({
+  type: 'element',
+  tagName: 'img',
+  properties: {
+    src: 'https://raw.githubusercontent.com/octocat/octocat/snake-output/snake.svg',
+  },
+  children: [],
+});
+
+describe('FEATURE - snake importer', () => {
+  it('returns a CanvasSection with type Sections.SNAKE and a string id', () => {
+    const result = snakeImporter(makeElement() as any);
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe(Sections.SNAKE);
+    expect(typeof result?.id).toBe('string');
+    expect(result?.id).not.toBe('');
+  });
+
+  it('returns a section even when the element has no children', () => {
+    const result = snakeImporter({ ...makeElement(), children: [] } as any);
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe(Sections.SNAKE);
+  });
+
+  it('does not mutate the shared defaultSnakeSectionConfig', () => {
+    const snapshot = structuredClone(defaultSnakeSectionConfig);
+
+    snakeImporter(makeElement() as any);
+    snakeImporter(makeElement() as any);
+
+    expect(defaultSnakeSectionConfig).toEqual(snapshot);
+  });
+});

--- a/src/features/snake/index/test.tsx
+++ b/src/features/snake/index/test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { runInAction } from 'mobx';
+
+import { command } from '#/lib/command';
+import { extensionsStore } from '#/stores/extensions-store';
+import { PanelsEnum, Sections } from '#/types';
+
+import { ExtensionsHandle } from '#/components/handles/extensions';
+
+import { defaultSnakeSectionConfig } from '../default-config';
+
+function resetExtensionsStore() {
+  runInAction(() => {
+    extensionsStore.extensions = {};
+    extensionsStore.registers = {};
+  });
+}
+
+describe('FEATURE - snake index (registration)', () => {
+  let unmount: () => void;
+  let disposeAdd: () => void;
+  const addHandler = vi.fn();
+
+  beforeAll(async () => {
+    resetExtensionsStore();
+    ({ unmount } = render(<ExtensionsHandle />));
+    disposeAdd = command.handle('canvas.section.add', addHandler);
+    await import('../index');
+  });
+
+  afterAll(() => {
+    unmount();
+    disposeAdd();
+    resetExtensionsStore();
+  });
+
+  it('registers the snake feature with id Sections.SNAKE', () => {
+    expect(extensionsStore.registers[Sections.SNAKE]).toBeDefined();
+    expect(extensionsStore.registers[Sections.SNAKE].id).toBe(Sections.SNAKE);
+  });
+
+  it('registers the NEW_SECTION presentation with icon and name', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.SNAKE];
+
+    expect(newSection).toBeDefined();
+    expect(newSection.icon).toBe('worm');
+    expect(newSection.name).toBe('Snake');
+  });
+
+  it('registers the sections readme and workflow parsers and defaultConfig', () => {
+    const register = extensionsStore.registers[Sections.SNAKE];
+    const sections = register.presentation.sections as any;
+
+    expect(typeof sections.parser.readme).toBe('function');
+    expect(typeof sections.parser.workflow).toBe('function');
+    expect(sections.defaultConfig).toEqual(defaultSnakeSectionConfig);
+  });
+
+  it('onClick dispatches canvas.section.add with Sections.SNAKE', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.SNAKE];
+
+    newSection.onClick();
+
+    expect(addHandler).toHaveBeenCalledWith(Sections.SNAKE);
+  });
+});

--- a/src/features/snake/index/test.tsx
+++ b/src/features/snake/index/test.tsx
@@ -41,8 +41,9 @@ describe('FEATURE - snake index (registration)', () => {
   });
 
   it('registers the NEW_SECTION presentation with icon and name', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.SNAKE];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.SNAKE
+    ] as any;
 
     expect(newSection).toBeDefined();
     expect(newSection.icon).toBe('worm');
@@ -59,8 +60,9 @@ describe('FEATURE - snake index (registration)', () => {
   });
 
   it('onClick dispatches canvas.section.add with Sections.SNAKE', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.SNAKE];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.SNAKE
+    ] as any;
 
     newSection.onClick();
 

--- a/src/features/snake/panel/test.tsx
+++ b/src/features/snake/panel/test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { SnakePanel } from '../panel';
+
+vi.mock('#/components/organisms/group-fields', () => ({
+  GroupFields: ({ id, label }: { id: number; label?: string }) => (
+    <div data-testid="group-fields" data-group-id={id} data-label={label} />
+  ),
+}));
+
+describe('FEATURE - SnakePanel', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders one GroupFields per group defined in panel/fields', () => {
+    render(<SnakePanel />);
+
+    const groups = screen.getAllByTestId('group-fields');
+
+    expect(groups).toHaveLength(1);
+  });
+
+  it('renders the single group with an empty label', () => {
+    render(<SnakePanel />);
+
+    const group = screen.getByTestId('group-fields');
+
+    expect(group.getAttribute('data-group-id')).toBe('1');
+    expect(group.getAttribute('data-label')).toBe('');
+  });
+});

--- a/src/features/snake/parser/test.ts
+++ b/src/features/snake/parser/test.ts
@@ -6,14 +6,18 @@ import { snakeSectionParser, snakeWorkflowParser } from '../parser';
 
 describe('FEATURE - snake parser', () => {
   it('emits an img with data-importer="snake"', () => {
-    const result = snakeSectionParser({}, { user: { github: 'octocat' } } as any);
+    const result = snakeSectionParser({}, {
+      user: { github: 'octocat' },
+    } as any);
 
     expect(result).toContain(`data-importer="${Sections.SNAKE}"`);
     expect(result).toContain('<img');
   });
 
   it('builds the src URL from settings.user.github', () => {
-    const result = snakeSectionParser({}, { user: { github: 'octocat' } } as any);
+    const result = snakeSectionParser({}, {
+      user: { github: 'octocat' },
+    } as any);
 
     expect(result).toContain(
       'src="https://raw.githubusercontent.com/octocat/octocat/snake-output/snake.svg"'
@@ -21,7 +25,9 @@ describe('FEATURE - snake parser', () => {
   });
 
   it('uses "Snake animation" as alt', () => {
-    const result = snakeSectionParser({}, { user: { github: 'octocat' } } as any);
+    const result = snakeSectionParser({}, {
+      user: { github: 'octocat' },
+    } as any);
 
     expect(result).toContain('alt="Snake animation"');
   });

--- a/src/features/snake/parser/test.ts
+++ b/src/features/snake/parser/test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+
+import { Sections } from '#/types';
+
+import { snakeSectionParser, snakeWorkflowParser } from '../parser';
+
+describe('FEATURE - snake parser', () => {
+  it('emits an img with data-importer="snake"', () => {
+    const result = snakeSectionParser({}, { user: { github: 'octocat' } } as any);
+
+    expect(result).toContain(`data-importer="${Sections.SNAKE}"`);
+    expect(result).toContain('<img');
+  });
+
+  it('builds the src URL from settings.user.github', () => {
+    const result = snakeSectionParser({}, { user: { github: 'octocat' } } as any);
+
+    expect(result).toContain(
+      'src="https://raw.githubusercontent.com/octocat/octocat/snake-output/snake.svg"'
+    );
+  });
+
+  it('uses "Snake animation" as alt', () => {
+    const result = snakeSectionParser({}, { user: { github: 'octocat' } } as any);
+
+    expect(result).toContain('alt="Snake animation"');
+  });
+
+  it('ignores the config argument', () => {
+    const r1 = snakeSectionParser({}, { user: { github: 'octocat' } } as any);
+    const r2 = snakeSectionParser(
+      { foo: 'bar' } as any,
+      { user: { github: 'octocat' } } as any
+    );
+
+    expect(r1).toBe(r2);
+  });
+
+  it('snakeWorkflowParser returns an object with file and content', () => {
+    const result = snakeWorkflowParser();
+
+    expect(result.file).toBe('snake.yml');
+    expect(typeof result.content).toBe('string');
+  });
+
+  it('snakeWorkflowParser content contains the workflow name', () => {
+    const result = snakeWorkflowParser();
+
+    expect(result.content).toContain('name: Generate snake animation');
+  });
+
+  it('snakeWorkflowParser content contains the snake action', () => {
+    const result = snakeWorkflowParser();
+
+    expect(result.content).toContain('Platane/snk/svg-only@v3');
+  });
+});

--- a/src/features/snake/section/test.tsx
+++ b/src/features/snake/section/test.tsx
@@ -32,9 +32,7 @@ describe('FEATURE - SnakeSection', () => {
   });
 
   it('renders an img with the snake svg src', () => {
-    const { container } = renderWithProvider(
-      <SnakeSection id="section-1" />
-    );
+    const { container } = renderWithProvider(<SnakeSection id="section-1" />);
 
     const img = container.querySelector('img');
 
@@ -43,9 +41,7 @@ describe('FEATURE - SnakeSection', () => {
   });
 
   it('renders the img with alt from translations', () => {
-    const { container } = renderWithProvider(
-      <SnakeSection id="section-1" />
-    );
+    const { container } = renderWithProvider(<SnakeSection id="section-1" />);
 
     expect(container.querySelector('img')?.getAttribute('alt')).toBe(
       'Snake animation'
@@ -53,9 +49,7 @@ describe('FEATURE - SnakeSection', () => {
   });
 
   it('renders the img with w-full class', () => {
-    const { container } = renderWithProvider(
-      <SnakeSection id="section-1" />
-    );
+    const { container } = renderWithProvider(<SnakeSection id="section-1" />);
 
     expect(container.querySelector('img')?.className).toContain('w-full');
   });

--- a/src/features/snake/section/test.tsx
+++ b/src/features/snake/section/test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import { SnakeSection } from '../section';
+
+vi.mock('#/components/organisms/sections/guard', () => ({
+  GuardSection: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="guard-section">{children}</div>
+  ),
+}));
+
+const messages = { ui: { alts: { snake: 'Snake animation' } } };
+
+function renderWithProvider(ui: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('FEATURE - SnakeSection', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('wraps content in GuardSection', () => {
+    const { getByTestId } = renderWithProvider(<SnakeSection id="section-1" />);
+
+    expect(getByTestId('guard-section')).not.toBeNull();
+  });
+
+  it('renders an img with the snake svg src', () => {
+    const { container } = renderWithProvider(
+      <SnakeSection id="section-1" />
+    );
+
+    const img = container.querySelector('img');
+
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toContain('snake.svg');
+  });
+
+  it('renders the img with alt from translations', () => {
+    const { container } = renderWithProvider(
+      <SnakeSection id="section-1" />
+    );
+
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe(
+      'Snake animation'
+    );
+  });
+
+  it('renders the img with w-full class', () => {
+    const { container } = renderWithProvider(
+      <SnakeSection id="section-1" />
+    );
+
+    expect(container.querySelector('img')?.className).toContain('w-full');
+  });
+});

--- a/src/features/socials/importer/test.ts
+++ b/src/features/socials/importer/test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { Sections } from '#/types';
+import { defaultSocialsSectionConfig } from '../default-config';
+
+import { socialsImporter } from '../importer';
+
+vi.mock('#/resources', () => ({
+  social_icons: [
+    {
+      name: 'linkedin',
+      icons: ['default'],
+      badge: {
+        message: 'LinkedIn',
+        color: '0077B5',
+        label: '',
+        logo: 'linkedin',
+        logoColor: 'white',
+      },
+    },
+    {
+      name: 'twitter',
+      icons: ['default'],
+      badge: {
+        message: 'X',
+        color: '000000',
+        label: '',
+        logo: 'x',
+        logoColor: 'white',
+      },
+    },
+  ],
+}));
+
+const makeImg = (alt: string, src: string, height = 40, width = 52) => ({
+  type: 'element',
+  tagName: 'img',
+  properties: { src, alt, height, width },
+  children: [],
+});
+
+const makeAnchorWithImg = (href: string, img: any) => ({
+  type: 'element',
+  tagName: 'a',
+  properties: { href },
+  children: [img],
+});
+
+const makeSocialsDiv = (children: unknown[], align = 'left') => ({
+  type: 'element',
+  tagName: 'div',
+  properties: { align },
+  children,
+});
+
+describe('FEATURE - socials importer', () => {
+  it('returns null when no element children are found', () => {
+    expect(socialsImporter(makeSocialsDiv([]) as any)).toBeNull();
+  });
+
+  it('returns a CanvasSection with type Sections.SOCIALS and a string id', () => {
+    const result = socialsImporter(
+      makeSocialsDiv([
+        makeImg('linkedin logo', 'https://cdn.simpleicons.org/linkedin/0077B5'),
+      ]) as any
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe(Sections.SOCIALS);
+    expect(typeof result?.id).toBe('string');
+    expect(result?.id).not.toBe('');
+  });
+
+  it('parses icons matching social_icons by alt name', () => {
+    const result = socialsImporter(
+      makeSocialsDiv([
+        makeImg('linkedin logo', 'https://cdn.simpleicons.org/linkedin/0077B5'),
+      ]) as any
+    );
+
+    expect(result?.props.content.socials).toHaveProperty('linkedin');
+  });
+
+  it('skips icons not found in social_icons', () => {
+    const result = socialsImporter(
+      makeSocialsDiv([
+        makeImg('unknownlogo', 'https://example.com/unknown.svg'),
+        makeImg('linkedin logo', 'https://cdn.simpleicons.org/linkedin/0077B5'),
+      ]) as any
+    );
+
+    expect(Object.keys(result?.props.content.socials)).toEqual(['linkedin']);
+  });
+
+  it('sets type to "icon" when src does not include "shields"', () => {
+    const result = socialsImporter(
+      makeSocialsDiv([
+        makeImg('linkedin logo', 'https://cdn.simpleicons.org/linkedin/0077B5'),
+      ]) as any
+    );
+
+    expect(result?.props.content.styles.type).toBe('icon');
+  });
+
+  it('sets type to "badge" when src includes "shields"', () => {
+    const result = socialsImporter(
+      makeSocialsDiv([
+        makeImg(
+          'linkedin logo',
+          'https://img.shields.io/badge/LinkedIn-0077B5?logo=linkedin&logoColor=white&style=for-the-badge'
+        ),
+      ]) as any
+    );
+
+    expect(result?.props.content.styles.type).toBe('badge');
+  });
+
+  it('extracts link from a wrapping anchor', () => {
+    const result = socialsImporter(
+      makeSocialsDiv([
+        makeAnchorWithImg(
+          'https://linkedin.com/in/user',
+          makeImg('linkedin logo', 'https://cdn.simpleicons.org/linkedin/0077B5')
+        ),
+      ]) as any
+    );
+
+    expect(result?.props.content.socials.linkedin.link).toBe(
+      'https://linkedin.com/in/user'
+    );
+  });
+
+  it('reads align from the element properties', () => {
+    const result = socialsImporter(
+      makeSocialsDiv(
+        [makeImg('linkedin logo', 'https://cdn.simpleicons.org/linkedin/0077B5')],
+        'right'
+      ) as any
+    );
+
+    expect(result?.props.styles.align).toBe('right');
+  });
+
+  it('does not mutate the shared defaultSocialsSectionConfig', () => {
+    const snapshot = structuredClone(defaultSocialsSectionConfig);
+
+    socialsImporter(
+      makeSocialsDiv([
+        makeImg('linkedin logo', 'https://cdn.simpleicons.org/linkedin/0077B5', 50),
+      ]) as any
+    );
+
+    expect(defaultSocialsSectionConfig).toEqual(snapshot);
+  });
+});

--- a/src/features/socials/importer/test.ts
+++ b/src/features/socials/importer/test.ts
@@ -120,7 +120,10 @@ describe('FEATURE - socials importer', () => {
       makeSocialsDiv([
         makeAnchorWithImg(
           'https://linkedin.com/in/user',
-          makeImg('linkedin logo', 'https://cdn.simpleicons.org/linkedin/0077B5')
+          makeImg(
+            'linkedin logo',
+            'https://cdn.simpleicons.org/linkedin/0077B5'
+          )
         ),
       ]) as any
     );
@@ -133,7 +136,12 @@ describe('FEATURE - socials importer', () => {
   it('reads align from the element properties', () => {
     const result = socialsImporter(
       makeSocialsDiv(
-        [makeImg('linkedin logo', 'https://cdn.simpleicons.org/linkedin/0077B5')],
+        [
+          makeImg(
+            'linkedin logo',
+            'https://cdn.simpleicons.org/linkedin/0077B5'
+          ),
+        ],
         'right'
       ) as any
     );
@@ -146,7 +154,11 @@ describe('FEATURE - socials importer', () => {
 
     socialsImporter(
       makeSocialsDiv([
-        makeImg('linkedin logo', 'https://cdn.simpleicons.org/linkedin/0077B5', 50),
+        makeImg(
+          'linkedin logo',
+          'https://cdn.simpleicons.org/linkedin/0077B5',
+          50
+        ),
       ]) as any
     );
 

--- a/src/features/socials/importer/test.ts
+++ b/src/features/socials/importer/test.ts
@@ -146,7 +146,7 @@ describe('FEATURE - socials importer', () => {
       ) as any
     );
 
-    expect(result?.props.styles.align).toBe('right');
+    expect(result?.props?.styles?.align).toBe('right');
   });
 
   it('does not mutate the shared defaultSocialsSectionConfig', () => {

--- a/src/features/socials/index/test.tsx
+++ b/src/features/socials/index/test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { runInAction } from 'mobx';
+
+import { command } from '#/lib/command';
+import { extensionsStore } from '#/stores/extensions-store';
+import { PanelsEnum, Sections } from '#/types';
+
+import { ExtensionsHandle } from '#/components/handles/extensions';
+
+import { defaultSocialsSectionConfig } from '../default-config';
+
+function resetExtensionsStore() {
+  runInAction(() => {
+    extensionsStore.extensions = {};
+    extensionsStore.registers = {};
+  });
+}
+
+describe('FEATURE - socials index (registration)', () => {
+  let unmount: () => void;
+  let disposeAdd: () => void;
+  const addHandler = vi.fn();
+
+  beforeAll(async () => {
+    resetExtensionsStore();
+    ({ unmount } = render(<ExtensionsHandle />));
+    disposeAdd = command.handle('canvas.section.add', addHandler);
+    await import('../index');
+  });
+
+  afterAll(() => {
+    unmount();
+    disposeAdd();
+    resetExtensionsStore();
+  });
+
+  it('registers the socials feature with id Sections.SOCIALS', () => {
+    expect(extensionsStore.registers[Sections.SOCIALS]).toBeDefined();
+    expect(extensionsStore.registers[Sections.SOCIALS].id).toBe(Sections.SOCIALS);
+  });
+
+  it('registers the NEW_SECTION presentation with icon and name', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.SOCIALS];
+
+    expect(newSection).toBeDefined();
+    expect(newSection.icon).toBe('message-square');
+    expect(newSection.name).toBe('Social Media');
+  });
+
+  it('registers the sections parser and defaultConfig', () => {
+    const register = extensionsStore.registers[Sections.SOCIALS];
+    const sections = register.presentation.sections as any;
+
+    expect(typeof sections.parser.readme).toBe('function');
+    expect(sections.defaultConfig).toEqual(defaultSocialsSectionConfig);
+  });
+
+  it('onClick dispatches canvas.section.add with Sections.SOCIALS', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.SOCIALS];
+
+    newSection.onClick();
+
+    expect(addHandler).toHaveBeenCalledWith(Sections.SOCIALS);
+  });
+});

--- a/src/features/socials/index/test.tsx
+++ b/src/features/socials/index/test.tsx
@@ -37,7 +37,9 @@ describe('FEATURE - socials index (registration)', () => {
 
   it('registers the socials feature with id Sections.SOCIALS', () => {
     expect(extensionsStore.registers[Sections.SOCIALS]).toBeDefined();
-    expect(extensionsStore.registers[Sections.SOCIALS].id).toBe(Sections.SOCIALS);
+    expect(extensionsStore.registers[Sections.SOCIALS].id).toBe(
+      Sections.SOCIALS
+    );
   });
 
   it('registers the NEW_SECTION presentation with icon and name', () => {

--- a/src/features/socials/panel/test.tsx
+++ b/src/features/socials/panel/test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+import { SocialsEditPanel } from '../panel';
+
+vi.mock('#/components/atoms/tabs', () => ({
+  Tabs: ({
+    tabs,
+    currentTab,
+    setCurrentTab,
+  }: {
+    tabs: { label: string; view: string }[];
+    currentTab: string;
+    setCurrentTab: (tab: string) => void;
+  }) => (
+    <div data-testid="tabs">
+      {tabs.map(tab => (
+        <button
+          key={tab.view}
+          data-testid={`tab-${tab.view}`}
+          data-active={currentTab === tab.view}
+          onClick={() => setCurrentTab(tab.view)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('./tabs', () => ({
+  tabs: [
+    { label: 'Add', icon: 'plus', view: 'adding' },
+    { label: 'Edit', icon: 'edit-2', view: 'editing' },
+  ],
+  views: {
+    adding: () => <div data-testid="view-adding">Adding View</div>,
+    editing: () => <div data-testid="view-editing">Editing View</div>,
+  },
+}));
+
+describe('FEATURE - SocialsEditPanel', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the Tabs component with the configured tabs', () => {
+    render(<SocialsEditPanel />);
+
+    expect(screen.getByTestId('tabs')).not.toBeNull();
+    expect(screen.getByTestId('tab-adding')).not.toBeNull();
+    expect(screen.getByTestId('tab-editing')).not.toBeNull();
+  });
+
+  it('renders the adding view by default', () => {
+    render(<SocialsEditPanel />);
+
+    expect(screen.getByTestId('view-adding')).not.toBeNull();
+    expect(screen.queryByTestId('view-editing')).toBeNull();
+  });
+
+  it('switches to the editing view when the edit tab is clicked', () => {
+    render(<SocialsEditPanel />);
+
+    fireEvent.click(screen.getByTestId('tab-editing'));
+
+    expect(screen.getByTestId('view-editing')).not.toBeNull();
+    expect(screen.queryByTestId('view-adding')).toBeNull();
+  });
+});

--- a/src/features/socials/parser/test.ts
+++ b/src/features/socials/parser/test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { Sections } from '#/types';
+
+import { socialsSectionParser } from '../parser';
+
+vi.mock('#/utils/url', () => ({
+  url: {
+    getSocialImg: vi.fn(
+      (type: string, social: string) => `https://example.com/${type}/${social}`
+    ),
+  },
+}));
+
+describe('FEATURE - socials parser', () => {
+  it('emits a div with data-importer="socials"', () => {
+    const result = socialsSectionParser({
+      content: {
+        socials: { linkedin: { icon: 'default', link: '' } },
+        styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain(`data-importer="${Sections.SOCIALS}"`);
+    expect(result).toContain('<div');
+    expect(result).toContain('</div>');
+  });
+
+  it('includes the align attribute on the wrapper div', () => {
+    const result = socialsSectionParser({
+      content: {
+        socials: { linkedin: { icon: 'default', link: '' } },
+        styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+      },
+      styles: { align: 'right', spacing: 12 },
+    });
+
+    expect(result).toContain('align="right"');
+  });
+
+  it('emits one img per social with the correct src and alt', () => {
+    const result = socialsSectionParser({
+      content: {
+        socials: {
+          linkedin: { icon: 'default', link: '' },
+          twitter: { icon: 'default', link: '' },
+        },
+        styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain('src="https://example.com/icon/linkedin"');
+    expect(result).toContain('alt="linkedin logo"');
+    expect(result).toContain('src="https://example.com/icon/twitter"');
+    expect(result).toContain('alt="twitter logo"');
+  });
+
+  it('includes width attr only for icon type (not badge)', () => {
+    const iconResult = socialsSectionParser({
+      content: {
+        socials: { linkedin: { icon: 'default', link: '' } },
+        styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    const badgeResult = socialsSectionParser({
+      content: {
+        socials: { linkedin: { icon: 'default', link: '' } },
+        styles: { type: 'badge', style: 'for-the-badge', height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(iconResult).toContain('width="52"');
+    expect(badgeResult).not.toContain('width=');
+  });
+
+  it('wraps the img in an anchor when link is present', () => {
+    const result = socialsSectionParser({
+      content: {
+        socials: { linkedin: { icon: 'default', link: 'https://linkedin.com/in/user' } },
+        styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain('<a href="https://linkedin.com/in/user" target="_blank">');
+    expect(result).toContain('</a>');
+  });
+
+  it('does not wrap the img in an anchor when link is absent', () => {
+    const result = socialsSectionParser({
+      content: {
+        socials: { linkedin: { icon: 'default', link: '' } },
+        styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).not.toContain('<a ');
+  });
+
+  it('defaults height to 40 when not provided', () => {
+    const result = socialsSectionParser({
+      content: {
+        socials: { linkedin: { icon: 'default', link: '' } },
+        styles: { type: 'icon', style: 'for-the-badge' } as any,
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain('height="40"');
+  });
+
+  it('computes width as height + spacing for icon type', () => {
+    const result = socialsSectionParser({
+      content: {
+        socials: { linkedin: { icon: 'default', link: '' } },
+        styles: { type: 'icon', style: 'for-the-badge', height: 30 },
+      },
+      styles: { align: 'center', spacing: 20 },
+    });
+
+    expect(result).toContain('width="50"');
+  });
+});

--- a/src/features/socials/parser/test.ts
+++ b/src/features/socials/parser/test.ts
@@ -81,13 +81,17 @@ describe('FEATURE - socials parser', () => {
   it('wraps the img in an anchor when link is present', () => {
     const result = socialsSectionParser({
       content: {
-        socials: { linkedin: { icon: 'default', link: 'https://linkedin.com/in/user' } },
+        socials: {
+          linkedin: { icon: 'default', link: 'https://linkedin.com/in/user' },
+        },
         styles: { type: 'icon', style: 'for-the-badge', height: 40 },
       },
       styles: { align: 'center', spacing: 12 },
     });
 
-    expect(result).toContain('<a href="https://linkedin.com/in/user" target="_blank">');
+    expect(result).toContain(
+      '<a href="https://linkedin.com/in/user" target="_blank">'
+    );
     expect(result).toContain('</a>');
   });
 

--- a/src/features/socials/section/test.tsx
+++ b/src/features/socials/section/test.tsx
@@ -68,8 +68,12 @@ describe('FEATURE - SocialsSection', () => {
     const imgs = container.querySelectorAll('img');
 
     expect(imgs).toHaveLength(2);
-    expect(imgs[0]?.getAttribute('src')).toBe('https://example.com/icon/linkedin');
-    expect(imgs[1]?.getAttribute('src')).toBe('https://example.com/icon/twitter');
+    expect(imgs[0]?.getAttribute('src')).toBe(
+      'https://example.com/icon/linkedin'
+    );
+    expect(imgs[1]?.getAttribute('src')).toBe(
+      'https://example.com/icon/twitter'
+    );
   });
 
   it('wraps the img in an anchor when link is present', () => {

--- a/src/features/socials/section/test.tsx
+++ b/src/features/socials/section/test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import { SocialsSection } from '../section';
+
+vi.mock('#/utils/url', () => ({
+  url: {
+    getSocialImg: vi.fn(
+      (type: string, social: string) => `https://example.com/${type}/${social}`
+    ),
+  },
+}));
+
+const messages = {
+  ui: {
+    alts: {
+      'social-logo': '{social} logo',
+    },
+  },
+};
+
+function renderWithProvider(ui: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('FEATURE - SocialsSection', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the wrapper div with flex flex-wrap and justify-content from align', () => {
+    const { container } = renderWithProvider(
+      <SocialsSection
+        content={{
+          socials: { linkedin: { icon: 'default', link: '' } },
+          styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+        }}
+        styles={{ align: 'center', spacing: 12 }}
+      />
+    );
+
+    const wrapper = container.querySelector('.flex');
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).toContain('flex-wrap');
+    expect(wrapper?.getAttribute('style')).toContain('justify-content: center');
+  });
+
+  it('renders one img per social with the correct src', () => {
+    const { container } = renderWithProvider(
+      <SocialsSection
+        content={{
+          socials: {
+            linkedin: { icon: 'default', link: '' },
+            twitter: { icon: 'default', link: '' },
+          },
+          styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+        }}
+        styles={{ align: 'center', spacing: 12 }}
+      />
+    );
+
+    const imgs = container.querySelectorAll('img');
+
+    expect(imgs).toHaveLength(2);
+    expect(imgs[0]?.getAttribute('src')).toBe('https://example.com/icon/linkedin');
+    expect(imgs[1]?.getAttribute('src')).toBe('https://example.com/icon/twitter');
+  });
+
+  it('wraps the img in an anchor when link is present', () => {
+    const { container } = renderWithProvider(
+      <SocialsSection
+        content={{
+          socials: {
+            linkedin: { icon: 'default', link: 'https://linkedin.com/in/user' },
+          },
+          styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+        }}
+        styles={{ align: 'center', spacing: 12 }}
+      />
+    );
+
+    const anchor = container.querySelector('a');
+
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe('https://linkedin.com/in/user');
+  });
+
+  it('does not wrap the img in an anchor when link is absent', () => {
+    const { container } = renderWithProvider(
+      <SocialsSection
+        content={{
+          socials: { linkedin: { icon: 'default', link: '' } },
+          styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+        }}
+        styles={{ align: 'center', spacing: 12 }}
+      />
+    );
+
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('applies height as inline style on each img', () => {
+    const { container } = renderWithProvider(
+      <SocialsSection
+        content={{
+          socials: { linkedin: { icon: 'default', link: '' } },
+          styles: { type: 'icon', style: 'for-the-badge', height: 50 },
+        }}
+        styles={{ align: 'center', spacing: 12 }}
+      />
+    );
+
+    expect(container.querySelector('img')?.style.height).toBe('50px');
+  });
+
+  it('uses spacing as gap for icon type', () => {
+    const { container } = renderWithProvider(
+      <SocialsSection
+        content={{
+          socials: { linkedin: { icon: 'default', link: '' } },
+          styles: { type: 'icon', style: 'for-the-badge', height: 40 },
+        }}
+        styles={{ align: 'center', spacing: 20 }}
+      />
+    );
+
+    expect(container.querySelector('.flex')?.getAttribute('style')).toContain(
+      'gap: 20px'
+    );
+  });
+
+  it('uses fixed gap of 5px for badge type', () => {
+    const { container } = renderWithProvider(
+      <SocialsSection
+        content={{
+          socials: { linkedin: { icon: 'default', link: '' } },
+          styles: { type: 'badge', style: 'for-the-badge', height: 40 },
+        }}
+        styles={{ align: 'center', spacing: 20 }}
+      />
+    );
+
+    expect(container.querySelector('.flex')?.getAttribute('style')).toContain(
+      'gap: 5px'
+    );
+  });
+});

--- a/src/features/stats/importer/test.ts
+++ b/src/features/stats/importer/test.ts
@@ -146,7 +146,7 @@ describe('FEATURE - stats importer', () => {
       ) as any
     );
 
-    expect(result?.props.styles.align).toBe('right');
+    expect(result?.props?.styles?.align).toBe('right');
   });
 
   it('defaults align to center when the element has no align property', () => {
@@ -159,7 +159,7 @@ describe('FEATURE - stats importer', () => {
       ]) as any
     );
 
-    expect(result?.props.styles.align).toBe('center');
+    expect(result?.props?.styles?.align).toBe('center');
   });
 
   it('sets show to false for graphs not present in the imported images', () => {

--- a/src/features/stats/importer/test.ts
+++ b/src/features/stats/importer/test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { Sections } from '#/types';
+import { defaultStatsSectionConfig } from '../default-config';
+
+import { statsImporter } from '../importer';
+
+vi.mock('#/config/general', () => ({
+  general: {
+    urls: {
+      sections: {
+        stats: {
+          streakBaseUrl: 'https://streak-stats.demolab.com',
+        },
+      },
+    },
+  },
+}));
+
+vi.mock('#/utils/object', () => ({
+  object: {
+    deep: {
+      set: vi.fn(({ obj, path, value }: any) => {
+        if (path === 'show') return { ...obj, show: value };
+        return obj;
+      }),
+    },
+  },
+}));
+
+const makeImg = (src: string, alt: string, height?: number) => ({
+  type: 'element',
+  tagName: 'img',
+  properties: {
+    src,
+    alt,
+    ...(height ? { height } : {}),
+  },
+  children: [],
+});
+
+const makeStatsDiv = (children: unknown[], align?: string) => ({
+  type: 'element',
+  tagName: 'div',
+  properties: align ? { align } : {},
+  children,
+});
+
+describe('FEATURE - stats importer', () => {
+  it('returns null when no img children with src and alt are found', () => {
+    expect(
+      statsImporter(
+        makeStatsDiv([
+          { type: 'element', tagName: 'img', properties: {}, children: [] },
+        ]) as any
+      )
+    ).toBeNull();
+  });
+
+  it('returns a CanvasSection with type Sections.STATS and a string id', () => {
+    const result = statsImporter(
+      makeStatsDiv([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/stats-output/stats.svg?theme=dark',
+          'stats graph'
+        ),
+      ]) as any
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe(Sections.STATS);
+    expect(typeof result?.id).toBe('string');
+    expect(result?.id).not.toBe('');
+  });
+
+  it('parses workflow-generated stats graph from raw.githubusercontent.com URL', () => {
+    const result = statsImporter(
+      makeStatsDiv([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/stats-output/stats.svg?theme=dark&hide_rank=true',
+          'stats graph'
+        ),
+      ]) as any
+    );
+
+    expect(result?.props.content.graphs.stats.show).toBe(true);
+    expect(result?.props.content.graphs.stats.theme).toBe('dark');
+    expect(result?.props.content.graphs.stats.hide_rank).toBe(true);
+  });
+
+  it('coerces "true" and "false" strings to booleans via mergeParamsToConfig', () => {
+    const result = statsImporter(
+      makeStatsDiv([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/stats-output/stats.svg?hide_title=true&hide_rank=false',
+          'stats graph'
+        ),
+      ]) as any
+    );
+
+    expect(result?.props.content.graphs.stats.hide_title).toBe(true);
+    expect(result?.props.content.graphs.stats.hide_rank).toBe(false);
+  });
+
+  it('coerces numeric strings to numbers via mergeParamsToConfig', () => {
+    const result = statsImporter(
+      makeStatsDiv([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/stats-output/stats.svg?card_width=320',
+          'stats graph'
+        ),
+      ]) as any
+    );
+
+    expect(result?.props.content.graphs.stats.card_width).toBe(320);
+  });
+
+  it('parses multiple graphs from multiple img children', () => {
+    const result = statsImporter(
+      makeStatsDiv([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/stats-output/stats.svg?theme=dark',
+          'stats graph'
+        ),
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/languages-output/languages.svg?layout=compact',
+          'languages graph'
+        ),
+      ]) as any
+    );
+
+    expect(result?.props.content.graphs.stats.show).toBe(true);
+    expect(result?.props.content.graphs.languages.show).toBe(true);
+  });
+
+  it('reads align from the element properties when present', () => {
+    const result = statsImporter(
+      makeStatsDiv(
+        [
+          makeImg(
+            'https://raw.githubusercontent.com/octocat/octocat/stats-output/stats.svg?theme=dark',
+            'stats graph'
+          ),
+        ],
+        'right'
+      ) as any
+    );
+
+    expect(result?.props.styles.align).toBe('right');
+  });
+
+  it('defaults align to center when the element has no align property', () => {
+    const result = statsImporter(
+      makeStatsDiv([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/stats-output/stats.svg?theme=dark',
+          'stats graph'
+        ),
+      ]) as any
+    );
+
+    expect(result?.props.styles.align).toBe('center');
+  });
+
+  it('sets show to false for graphs not present in the imported images', () => {
+    const result = statsImporter(
+      makeStatsDiv([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/stats-output/stats.svg?theme=dark',
+          'stats graph'
+        ),
+      ]) as any
+    );
+
+    expect(result?.props.content.graphs.languages.show).toBe(false);
+  });
+
+  it('does not mutate the shared defaultStatsSectionConfig', () => {
+    const snapshot = structuredClone(defaultStatsSectionConfig);
+
+    statsImporter(
+      makeStatsDiv([
+        makeImg(
+          'https://raw.githubusercontent.com/octocat/octocat/stats-output/stats.svg?theme=light',
+          'stats graph'
+        ),
+      ]) as any
+    );
+
+    expect(defaultStatsSectionConfig).toEqual(snapshot);
+  });
+});

--- a/src/features/stats/index/test.tsx
+++ b/src/features/stats/index/test.tsx
@@ -41,8 +41,9 @@ describe('FEATURE - stats index (registration)', () => {
   });
 
   it('registers the NEW_SECTION presentation with icon and name', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.STATS];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.STATS
+    ] as any;
 
     expect(newSection).toBeDefined();
     expect(newSection.icon).toBe('pie-chart');
@@ -59,8 +60,9 @@ describe('FEATURE - stats index (registration)', () => {
   });
 
   it('onClick dispatches canvas.section.add with Sections.STATS', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.STATS];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.STATS
+    ] as any;
 
     newSection.onClick();
 

--- a/src/features/stats/index/test.tsx
+++ b/src/features/stats/index/test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { runInAction } from 'mobx';
+
+import { command } from '#/lib/command';
+import { extensionsStore } from '#/stores/extensions-store';
+import { PanelsEnum, Sections } from '#/types';
+
+import { ExtensionsHandle } from '#/components/handles/extensions';
+
+import { defaultStatsSectionConfig } from '../default-config';
+
+function resetExtensionsStore() {
+  runInAction(() => {
+    extensionsStore.extensions = {};
+    extensionsStore.registers = {};
+  });
+}
+
+describe('FEATURE - stats index (registration)', () => {
+  let unmount: () => void;
+  let disposeAdd: () => void;
+  const addHandler = vi.fn();
+
+  beforeAll(async () => {
+    resetExtensionsStore();
+    ({ unmount } = render(<ExtensionsHandle />));
+    disposeAdd = command.handle('canvas.section.add', addHandler);
+    await import('../index');
+  });
+
+  afterAll(() => {
+    unmount();
+    disposeAdd();
+    resetExtensionsStore();
+  });
+
+  it('registers the stats feature with id Sections.STATS', () => {
+    expect(extensionsStore.registers[Sections.STATS]).toBeDefined();
+    expect(extensionsStore.registers[Sections.STATS].id).toBe(Sections.STATS);
+  });
+
+  it('registers the NEW_SECTION presentation with icon and name', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.STATS];
+
+    expect(newSection).toBeDefined();
+    expect(newSection.icon).toBe('pie-chart');
+    expect(newSection.name).toBe('Stats');
+  });
+
+  it('registers the sections readme and workflow parsers and defaultConfig', () => {
+    const register = extensionsStore.registers[Sections.STATS];
+    const sections = register.presentation.sections as any;
+
+    expect(typeof sections.parser.readme).toBe('function');
+    expect(typeof sections.parser.workflow).toBe('function');
+    expect(sections.defaultConfig).toEqual(defaultStatsSectionConfig);
+  });
+
+  it('onClick dispatches canvas.section.add with Sections.STATS', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.STATS];
+
+    newSection.onClick();
+
+    expect(addHandler).toHaveBeenCalledWith(Sections.STATS);
+  });
+});

--- a/src/features/stats/panel/test.tsx
+++ b/src/features/stats/panel/test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+import { StatsEditPanel } from '../panel';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: vi.fn(),
+  }),
+  usePathname: () => '/test',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('#/components/atoms/tabs', () => ({
+  Tabs: ({
+    tabs,
+    currentTab,
+    setCurrentTab,
+  }: {
+    tabs: { label: string; view: string }[];
+    currentTab: string;
+    setCurrentTab: (tab: string) => void;
+  }) => (
+    <div data-testid="tabs">
+      {tabs.map(tab => (
+        <button
+          key={tab.view}
+          data-testid={`tab-${tab.view}`}
+          data-active={currentTab === tab.view}
+          onClick={() => setCurrentTab(tab.view)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('#/components/organisms/panel', () => {
+  const Panel = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="panel">{children}</div>
+  );
+  Panel.Scrollable = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="panel-scrollable">{children}</div>
+  );
+  return { Panel };
+});
+
+vi.mock('./tabs', () => ({
+  tabs: [
+    { label: 'Layout', icon: 'layout', view: 'layout' },
+    { label: 'Config Stats', icon: 'settings', view: 'config' },
+  ],
+  views: {
+    layout: () => <div data-testid="view-layout">Layout View</div>,
+    config: () => <div data-testid="view-config">Config View</div>,
+  },
+}));
+
+describe('FEATURE - StatsEditPanel', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the Tabs component with the configured tabs', () => {
+    render(<StatsEditPanel />);
+
+    expect(screen.getByTestId('tabs')).not.toBeNull();
+    expect(screen.getByTestId('tab-layout')).not.toBeNull();
+    expect(screen.getByTestId('tab-config')).not.toBeNull();
+  });
+
+  it('renders the layout view by default', () => {
+    render(<StatsEditPanel />);
+
+    expect(screen.getByTestId('view-layout')).not.toBeNull();
+    expect(screen.queryByTestId('view-config')).toBeNull();
+  });
+
+  it('wraps the view in Panel.Scrollable', () => {
+    render(<StatsEditPanel />);
+
+    expect(screen.getAllByTestId('panel-scrollable')).toHaveLength(1);
+  });
+
+  it('switches to the config view when the config tab is clicked', () => {
+    render(<StatsEditPanel />);
+
+    fireEvent.click(screen.getByTestId('tab-config'));
+
+    expect(screen.getByTestId('view-config')).not.toBeNull();
+    expect(screen.queryByTestId('view-layout')).toBeNull();
+  });
+});

--- a/src/features/stats/parser/test.ts
+++ b/src/features/stats/parser/test.ts
@@ -6,7 +6,10 @@ import { statsSectionParser, statsWorkflowParser } from '../parser';
 
 vi.mock('#/utils/url', () => ({
   url: {
-    getStats: vi.fn((type: string, github: string) => `https://stats.example.com/${type}?username=${github}`),
+    getStats: vi.fn(
+      (type: string, github: string) =>
+        `https://stats.example.com/${type}?username=${github}`
+    ),
   },
 }));
 
@@ -151,7 +154,9 @@ describe('FEATURE - stats parser (readme)', () => {
       settings
     );
 
-    expect(result).toContain('src="https://stats.example.com/streak?username=octocat&"');
+    expect(result).toContain(
+      'src="https://stats.example.com/streak?username=octocat&"'
+    );
   });
 
   it('defaults height to 150 when not provided', () => {

--- a/src/features/stats/parser/test.ts
+++ b/src/features/stats/parser/test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { Sections } from '#/types';
+
+import { statsSectionParser, statsWorkflowParser } from '../parser';
+
+vi.mock('#/utils/url', () => ({
+  url: {
+    getStats: vi.fn((type: string, github: string) => `https://stats.example.com/${type}?username=${github}`),
+  },
+}));
+
+vi.mock('#/utils/object', () => ({
+  object: {
+    toQueryParams: vi.fn((params: Record<string, unknown>) =>
+      Object.entries(params)
+        .filter(([, v]) => v !== undefined && v !== null && v !== '')
+        .map(([k, v]) => `${k}=${v}`)
+        .join('&')
+    ),
+  },
+}));
+
+const settings = { user: { github: 'octocat' } } as any;
+
+describe('FEATURE - stats parser (readme)', () => {
+  it('emits a div with data-importer="stats"', () => {
+    const result = statsSectionParser(
+      {
+        content: { graphs: { stats: { show: true } } as any },
+        styles: { align: 'center', direction: 'row' },
+      },
+      settings
+    );
+
+    expect(result).toContain(`data-importer="${Sections.STATS}"`);
+    expect(result).toContain('<div');
+    expect(result).toContain('</div>');
+  });
+
+  it('includes the align attribute on the wrapper div', () => {
+    const result = statsSectionParser(
+      {
+        content: { graphs: { stats: { show: true } } as any },
+        styles: { align: 'right', direction: 'row' },
+      },
+      settings
+    );
+
+    expect(result).toContain('align="right"');
+  });
+
+  it('filters out graphs where show is false', () => {
+    const result = statsSectionParser(
+      {
+        content: {
+          graphs: {
+            stats: { show: true },
+            languages: { show: false },
+          } as any,
+        },
+        styles: { align: 'center', direction: 'row' },
+      },
+      settings
+    );
+
+    expect(result).toContain('alt="stats graph"');
+    expect(result).not.toContain('alt="languages graph"');
+  });
+
+  it('emits one img per visible graph', () => {
+    const result = statsSectionParser(
+      {
+        content: {
+          graphs: {
+            stats: { show: true },
+            languages: { show: true },
+          } as any,
+        },
+        styles: { align: 'center', direction: 'row' },
+      },
+      settings
+    );
+
+    const imgCount = (result.match(/<img /g) || []).length;
+    expect(imgCount).toBe(2);
+  });
+
+  it('adds <br> between graphs when direction is column', () => {
+    const result = statsSectionParser(
+      {
+        content: {
+          graphs: {
+            stats: { show: true },
+            languages: { show: true },
+          } as any,
+        },
+        styles: { align: 'center', direction: 'column' },
+      },
+      settings
+    );
+
+    expect(result).toContain('<br>');
+  });
+
+  it('does not add <br> when direction is row', () => {
+    const result = statsSectionParser(
+      {
+        content: {
+          graphs: {
+            stats: { show: true },
+            languages: { show: true },
+          } as any,
+        },
+        styles: { align: 'center', direction: 'row' },
+      },
+      settings
+    );
+
+    expect(result).not.toContain('<br>');
+  });
+
+  it('uses workflow file URL for workflow-based graphs (stats, languages, trophy, activity-graph)', () => {
+    const result = statsSectionParser(
+      {
+        content: {
+          graphs: {
+            stats: { show: true, theme: 'dark' },
+          } as any,
+        },
+        styles: { align: 'center', direction: 'row' },
+      },
+      settings
+    );
+
+    expect(result).toContain(
+      'src="https://raw.githubusercontent.com/octocat/octocat/stats-output/stats.svg?'
+    );
+  });
+
+  it('uses url.getStats for non-workflow graphs (streak)', () => {
+    const result = statsSectionParser(
+      {
+        content: {
+          graphs: {
+            streak: { show: true },
+          } as any,
+        },
+        styles: { align: 'center', direction: 'row' },
+      },
+      settings
+    );
+
+    expect(result).toContain('src="https://stats.example.com/streak?username=octocat&"');
+  });
+
+  it('defaults height to 150 when not provided', () => {
+    const result = statsSectionParser(
+      {
+        content: {
+          graphs: { stats: { show: true } } as any,
+        },
+        styles: { align: 'center', direction: 'row' },
+      },
+      settings
+    );
+
+    expect(result).toContain('height="150"');
+  });
+});
+
+describe('FEATURE - stats parser (workflow)', () => {
+  it('returns null when no graphs are visible', () => {
+    const result = statsWorkflowParser({
+      content: {
+        graphs: {
+          stats: { show: false },
+          languages: { show: false },
+          trophy: { show: false },
+          'activity-graph': { show: false },
+        } as any,
+      },
+      styles: { align: 'center', direction: 'row' },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns an array of TFile when at least one graph is visible', () => {
+    const result = statsWorkflowParser({
+      content: {
+        graphs: {
+          stats: { show: true },
+          languages: { show: false },
+          trophy: { show: false },
+          'activity-graph': { show: false },
+        } as any,
+      },
+      styles: { align: 'center', direction: 'row' },
+    });
+
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result!.length).toBe(1);
+    expect(result![0].file).toBe('stats.yml');
+  });
+
+  it('returns multiple workflow files when multiple graphs are visible', () => {
+    const result = statsWorkflowParser({
+      content: {
+        graphs: {
+          stats: { show: true },
+          languages: { show: true },
+          trophy: { show: true },
+          'activity-graph': { show: true },
+        } as any,
+      },
+      styles: { align: 'center', direction: 'row' },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(4);
+    const files = result!.map((w: any) => w.file);
+    expect(files).toContain('stats.yml');
+    expect(files).toContain('languages.yml');
+    expect(files).toContain('trophy.yml');
+    expect(files).toContain('activity-graph.yml');
+  });
+
+  it('stats workflow content contains the workflow name', () => {
+    const result = statsWorkflowParser({
+      content: {
+        graphs: { stats: { show: true } } as any,
+      },
+      styles: { align: 'center', direction: 'row' },
+    });
+
+    expect(result![0].content).toContain('name: Generate stats card');
+  });
+
+  it('languages workflow content contains the workflow name', () => {
+    const result = statsWorkflowParser({
+      content: {
+        graphs: { languages: { show: true } } as any,
+      },
+      styles: { align: 'center', direction: 'row' },
+    });
+
+    expect(result![0].content).toContain('name: Generate languages card');
+  });
+
+  it('trophy workflow content contains the workflow name', () => {
+    const result = statsWorkflowParser({
+      content: {
+        graphs: { trophy: { show: true } } as any,
+      },
+      styles: { align: 'center', direction: 'row' },
+    });
+
+    expect(result![0].content).toContain('name: Generate trophy card');
+  });
+
+  it('activity-graph workflow content contains the workflow name', () => {
+    const result = statsWorkflowParser({
+      content: {
+        graphs: { 'activity-graph': { show: true } } as any,
+      },
+      styles: { align: 'center', direction: 'row' },
+    });
+
+    expect(result![0].content).toContain('name: Update Activity Graph');
+  });
+});

--- a/src/features/stats/section/test.tsx
+++ b/src/features/stats/section/test.tsx
@@ -15,7 +15,10 @@ vi.mock('#/components/organisms/sections/guard', () => ({
 
 vi.mock('#/utils/url', () => ({
   url: {
-    getStats: vi.fn((type: string, github: string) => `https://stats.example.com/${type}?username=${github}`),
+    getStats: vi.fn(
+      (type: string, github: string) =>
+        `https://stats.example.com/${type}?username=${github}`
+    ),
   },
 }));
 

--- a/src/features/stats/section/test.tsx
+++ b/src/features/stats/section/test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import { runInAction } from 'mobx';
+
+import { settingsStore } from '#/stores/settings-store';
+
+import { StatsSection } from '../section';
+
+vi.mock('#/components/organisms/sections/guard', () => ({
+  GuardSection: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="guard-section">{children}</div>
+  ),
+}));
+
+vi.mock('#/utils/url', () => ({
+  url: {
+    getStats: vi.fn((type: string, github: string) => `https://stats.example.com/${type}?username=${github}`),
+  },
+}));
+
+vi.mock('#/utils/object', () => ({
+  object: {
+    toQueryParams: vi.fn((params: Record<string, unknown>) =>
+      Object.entries(params)
+        .filter(([, v]) => v !== undefined && v !== null && v !== '')
+        .map(([k, v]) => `${k}=${v}`)
+        .join('&')
+    ),
+  },
+}));
+
+vi.mock('#/hooks', () => ({
+  useSettings: () => settingsStore,
+}));
+
+const messages = {
+  ui: {
+    alts: {
+      graph: '{graph} graph',
+    },
+  },
+};
+
+function renderWithProvider(ui: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('FEATURE - StatsSection', () => {
+  afterEach(() => {
+    cleanup();
+    runInAction(() => {
+      settingsStore.$settings.user.github = undefined;
+    });
+  });
+
+  it('wraps content in GuardSection', () => {
+    runInAction(() => {
+      settingsStore.$settings.user.github = 'octocat';
+    });
+
+    const { getByTestId } = renderWithProvider(
+      <StatsSection
+        id="section-1"
+        content={{ graphs: { stats: { show: true } } as any }}
+        styles={{ align: 'center', direction: 'row' }}
+      />
+    );
+
+    expect(getByTestId('guard-section')).not.toBeNull();
+  });
+
+  it('renders one img per visible graph', () => {
+    runInAction(() => {
+      settingsStore.$settings.user.github = 'octocat';
+    });
+
+    const { container } = renderWithProvider(
+      <StatsSection
+        id="section-1"
+        content={{
+          graphs: {
+            stats: { show: true, theme: 'dark' },
+            languages: { show: true, layout: 'compact' },
+          } as any,
+        }}
+        styles={{ align: 'center', direction: 'row' }}
+      />
+    );
+
+    const imgs = container.querySelectorAll('img');
+    expect(imgs).toHaveLength(2);
+  });
+
+  it('does not render hidden graphs', () => {
+    runInAction(() => {
+      settingsStore.$settings.user.github = 'octocat';
+    });
+
+    const { container } = renderWithProvider(
+      <StatsSection
+        id="section-1"
+        content={{
+          graphs: {
+            stats: { show: true },
+            languages: { show: false },
+          } as any,
+        }}
+        styles={{ align: 'center', direction: 'row' }}
+      />
+    );
+
+    expect(container.querySelectorAll('img')).toHaveLength(1);
+  });
+
+  it('applies justifyContent for row direction from align', () => {
+    runInAction(() => {
+      settingsStore.$settings.user.github = 'octocat';
+    });
+
+    const { container } = renderWithProvider(
+      <StatsSection
+        id="section-1"
+        content={{ graphs: { stats: { show: true } } as any }}
+        styles={{ align: 'right', direction: 'row' }}
+      />
+    );
+
+    const wrapper = container.querySelector('.flex');
+    expect(wrapper?.getAttribute('style')).toContain('justify-content: right');
+  });
+
+  it('applies alignContent for column direction from align', () => {
+    runInAction(() => {
+      settingsStore.$settings.user.github = 'octocat';
+    });
+
+    const { container } = renderWithProvider(
+      <StatsSection
+        id="section-1"
+        content={{ graphs: { stats: { show: true } } as any }}
+        styles={{ align: 'right', direction: 'column' }}
+      />
+    );
+
+    const wrapper = container.querySelector('.flex');
+    expect(wrapper?.getAttribute('style')).toContain('align-content: end');
+  });
+
+  it('renders the img with max-w-full class', () => {
+    runInAction(() => {
+      settingsStore.$settings.user.github = 'octocat';
+    });
+
+    const { container } = renderWithProvider(
+      <StatsSection
+        id="section-1"
+        content={{ graphs: { stats: { show: true } } as any }}
+        styles={{ align: 'center', direction: 'row' }}
+      />
+    );
+
+    expect(container.querySelector('img')?.className).toContain('max-w-full');
+  });
+});

--- a/src/features/techs/importer/test.ts
+++ b/src/features/techs/importer/test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { Sections } from '#/types';
+import { defaultTechsSectionConfig } from '../default-config';
+
+import { techsImporter } from '../importer';
+
+vi.mock('#/resources', () => ({
+  tech_icons: [
+    {
+      name: 'javascript',
+      color: '#F7DF1E',
+      alias: ['js'],
+      tags: [],
+      available_providers: ['simple_icons', 'devicons'],
+      providers: {
+        simple_icons: { path: 'https://cdn.simpleicons.org/javascript/F7DF1E' },
+        devicons: {
+          path: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg',
+        },
+      },
+    },
+  ],
+}));
+
+const makeImg = (alt: string, src: string, height = 40) => ({
+  type: 'element',
+  tagName: 'img',
+  properties: { src, alt, height },
+  children: [],
+});
+
+const makeSpacingImg = (width = 12) => ({
+  type: 'element',
+  tagName: 'img',
+  properties: { width },
+  children: [],
+});
+
+const makeTechsDiv = (children: unknown[], align = 'left') => ({
+  type: 'element',
+  tagName: 'div',
+  properties: { align },
+  children,
+});
+
+describe('FEATURE - techs importer', () => {
+  it('returns null when no img children with src and alt are found', () => {
+    expect(
+      techsImporter(
+        makeTechsDiv([
+          { type: 'element', tagName: 'img', properties: {}, children: [] },
+        ]) as any
+      )
+    ).toBeNull();
+  });
+
+  it('returns a CanvasSection with type Sections.TECHS and a string id', () => {
+    const result = techsImporter(
+      makeTechsDiv([
+        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E'),
+      ]) as any
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe(Sections.TECHS);
+    expect(typeof result?.id).toBe('string');
+    expect(result?.id).not.toBe('');
+  });
+
+  it('parses icons matching tech_icons by alt name', () => {
+    const result = techsImporter(
+      makeTechsDiv([
+        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E'),
+      ]) as any
+    );
+
+    expect(result?.props.content.icons).toHaveProperty('javascript');
+    expect(result?.props.content.icons.javascript.currentProvider).toBe(
+      'simple_icons'
+    );
+  });
+
+  it('skips icons not found in tech_icons', () => {
+    const result = techsImporter(
+      makeTechsDiv([
+        makeImg('unknownlogo', 'https://example.com/unknown.svg'),
+        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E'),
+      ]) as any
+    );
+
+    expect(Object.keys(result?.props.content.icons)).toEqual(['javascript']);
+  });
+
+  it('extracts height from the first image', () => {
+    const result = techsImporter(
+      makeTechsDiv([
+        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E', 50),
+      ]) as any
+    );
+
+    expect(result?.props.content.styles.height).toBe(50);
+  });
+
+  it('reads align from the element properties', () => {
+    const result = techsImporter(
+      makeTechsDiv(
+        [makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E')],
+        'right'
+      ) as any
+    );
+
+    expect(result?.props.styles.align).toBe('right');
+  });
+
+  it('extracts spacing from the first spacing image width', () => {
+    const result = techsImporter(
+      makeTechsDiv([
+        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E'),
+        makeSpacingImg(20),
+        makeImg('react logo', 'https://cdn.simpleicons.org/react/61DAFB'),
+      ]) as any
+    );
+
+    expect(result?.props.styles.spacing).toBe(20);
+  });
+
+  it('defaults spacing to 12 when no spacing image is found', () => {
+    const result = techsImporter(
+      makeTechsDiv([
+        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E'),
+      ]) as any
+    );
+
+    expect(result?.props.styles.spacing).toBe(12);
+  });
+
+  it('does not mutate the shared defaultTechsSectionConfig', () => {
+    const snapshot = structuredClone(defaultTechsSectionConfig);
+
+    techsImporter(
+      makeTechsDiv([
+        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E', 60),
+      ]) as any
+    );
+
+    expect(defaultTechsSectionConfig).toEqual(snapshot);
+  });
+});

--- a/src/features/techs/importer/test.ts
+++ b/src/features/techs/importer/test.ts
@@ -58,7 +58,10 @@ describe('FEATURE - techs importer', () => {
   it('returns a CanvasSection with type Sections.TECHS and a string id', () => {
     const result = techsImporter(
       makeTechsDiv([
-        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E'),
+        makeImg(
+          'javascript logo',
+          'https://cdn.simpleicons.org/javascript/F7DF1E'
+        ),
       ]) as any
     );
 
@@ -71,7 +74,10 @@ describe('FEATURE - techs importer', () => {
   it('parses icons matching tech_icons by alt name', () => {
     const result = techsImporter(
       makeTechsDiv([
-        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E'),
+        makeImg(
+          'javascript logo',
+          'https://cdn.simpleicons.org/javascript/F7DF1E'
+        ),
       ]) as any
     );
 
@@ -85,7 +91,10 @@ describe('FEATURE - techs importer', () => {
     const result = techsImporter(
       makeTechsDiv([
         makeImg('unknownlogo', 'https://example.com/unknown.svg'),
-        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E'),
+        makeImg(
+          'javascript logo',
+          'https://cdn.simpleicons.org/javascript/F7DF1E'
+        ),
       ]) as any
     );
 
@@ -95,7 +104,11 @@ describe('FEATURE - techs importer', () => {
   it('extracts height from the first image', () => {
     const result = techsImporter(
       makeTechsDiv([
-        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E', 50),
+        makeImg(
+          'javascript logo',
+          'https://cdn.simpleicons.org/javascript/F7DF1E',
+          50
+        ),
       ]) as any
     );
 
@@ -105,7 +118,12 @@ describe('FEATURE - techs importer', () => {
   it('reads align from the element properties', () => {
     const result = techsImporter(
       makeTechsDiv(
-        [makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E')],
+        [
+          makeImg(
+            'javascript logo',
+            'https://cdn.simpleicons.org/javascript/F7DF1E'
+          ),
+        ],
         'right'
       ) as any
     );
@@ -116,7 +134,10 @@ describe('FEATURE - techs importer', () => {
   it('extracts spacing from the first spacing image width', () => {
     const result = techsImporter(
       makeTechsDiv([
-        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E'),
+        makeImg(
+          'javascript logo',
+          'https://cdn.simpleicons.org/javascript/F7DF1E'
+        ),
         makeSpacingImg(20),
         makeImg('react logo', 'https://cdn.simpleicons.org/react/61DAFB'),
       ]) as any
@@ -128,7 +149,10 @@ describe('FEATURE - techs importer', () => {
   it('defaults spacing to 12 when no spacing image is found', () => {
     const result = techsImporter(
       makeTechsDiv([
-        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E'),
+        makeImg(
+          'javascript logo',
+          'https://cdn.simpleicons.org/javascript/F7DF1E'
+        ),
       ]) as any
     );
 
@@ -140,7 +164,11 @@ describe('FEATURE - techs importer', () => {
 
     techsImporter(
       makeTechsDiv([
-        makeImg('javascript logo', 'https://cdn.simpleicons.org/javascript/F7DF1E', 60),
+        makeImg(
+          'javascript logo',
+          'https://cdn.simpleicons.org/javascript/F7DF1E',
+          60
+        ),
       ]) as any
     );
 

--- a/src/features/techs/importer/test.ts
+++ b/src/features/techs/importer/test.ts
@@ -128,7 +128,7 @@ describe('FEATURE - techs importer', () => {
       ) as any
     );
 
-    expect(result?.props.styles.align).toBe('right');
+    expect(result?.props?.styles?.align).toBe('right');
   });
 
   it('extracts spacing from the first spacing image width', () => {
@@ -143,7 +143,7 @@ describe('FEATURE - techs importer', () => {
       ]) as any
     );
 
-    expect(result?.props.styles.spacing).toBe(20);
+    expect(result?.props?.styles?.spacing).toBe(20);
   });
 
   it('defaults spacing to 12 when no spacing image is found', () => {
@@ -156,7 +156,7 @@ describe('FEATURE - techs importer', () => {
       ]) as any
     );
 
-    expect(result?.props.styles.spacing).toBe(12);
+    expect(result?.props?.styles?.spacing).toBe(12);
   });
 
   it('does not mutate the shared defaultTechsSectionConfig', () => {

--- a/src/features/techs/index/test.tsx
+++ b/src/features/techs/index/test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { runInAction } from 'mobx';
+
+import { command } from '#/lib/command';
+import { extensionsStore } from '#/stores/extensions-store';
+import { PanelsEnum, Sections } from '#/types';
+
+import { ExtensionsHandle } from '#/components/handles/extensions';
+
+import { defaultTechsSectionConfig } from '../default-config';
+
+function resetExtensionsStore() {
+  runInAction(() => {
+    extensionsStore.extensions = {};
+    extensionsStore.registers = {};
+  });
+}
+
+describe('FEATURE - techs index (registration)', () => {
+  let unmount: () => void;
+  let disposeAdd: () => void;
+  const addHandler = vi.fn();
+
+  beforeAll(async () => {
+    resetExtensionsStore();
+    ({ unmount } = render(<ExtensionsHandle />));
+    disposeAdd = command.handle('canvas.section.add', addHandler);
+    await import('../index');
+  });
+
+  afterAll(() => {
+    unmount();
+    disposeAdd();
+    resetExtensionsStore();
+  });
+
+  it('registers the techs feature with id Sections.TECHS', () => {
+    expect(extensionsStore.registers[Sections.TECHS]).toBeDefined();
+    expect(extensionsStore.registers[Sections.TECHS].id).toBe(Sections.TECHS);
+  });
+
+  it('registers the NEW_SECTION presentation with icon and name', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.TECHS];
+
+    expect(newSection).toBeDefined();
+    expect(newSection.icon).toBe('cpu');
+    expect(newSection.name).toBe('Techs');
+  });
+
+  it('registers the sections parser and defaultConfig', () => {
+    const register = extensionsStore.registers[Sections.TECHS];
+    const sections = register.presentation.sections as any;
+
+    expect(typeof sections.parser.readme).toBe('function');
+    expect(sections.defaultConfig).toEqual(defaultTechsSectionConfig);
+  });
+
+  it('onClick dispatches canvas.section.add with Sections.TECHS', () => {
+    const newSection =
+      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.TECHS];
+
+    newSection.onClick();
+
+    expect(addHandler).toHaveBeenCalledWith(Sections.TECHS);
+  });
+});

--- a/src/features/techs/index/test.tsx
+++ b/src/features/techs/index/test.tsx
@@ -41,8 +41,9 @@ describe('FEATURE - techs index (registration)', () => {
   });
 
   it('registers the NEW_SECTION presentation with icon and name', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.TECHS];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.TECHS
+    ] as any;
 
     expect(newSection).toBeDefined();
     expect(newSection.icon).toBe('cpu');
@@ -58,8 +59,9 @@ describe('FEATURE - techs index (registration)', () => {
   });
 
   it('onClick dispatches canvas.section.add with Sections.TECHS', () => {
-    const newSection =
-      extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[Sections.TECHS];
+    const newSection = extensionsStore.extensions[PanelsEnum.NEW_SECTION]?.[
+      Sections.TECHS
+    ] as any;
 
     newSection.onClick();
 

--- a/src/features/techs/panel/test.tsx
+++ b/src/features/techs/panel/test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+import { TechsEditPanel } from '../panel';
+
+vi.mock('#/components/atoms/tabs', () => ({
+  Tabs: ({
+    tabs,
+    currentTab,
+    setCurrentTab,
+  }: {
+    tabs: { label: string; view: string }[];
+    currentTab: string;
+    setCurrentTab: (tab: string) => void;
+  }) => (
+    <div data-testid="tabs">
+      {tabs.map(tab => (
+        <button
+          key={tab.view}
+          data-testid={`tab-${tab.view}`}
+          data-active={currentTab === tab.view}
+          onClick={() => setCurrentTab(tab.view)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('./tabs', () => ({
+  tabs: [
+    { label: 'Add', icon: 'plus', view: 'adding' },
+    { label: 'Edit', icon: 'edit-2', view: 'editing' },
+  ],
+  views: {
+    adding: () => <div data-testid="view-adding">Adding View</div>,
+    editing: () => <div data-testid="view-editing">Editing View</div>,
+  },
+}));
+
+describe('FEATURE - TechsEditPanel', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the Tabs component with the configured tabs', () => {
+    render(<TechsEditPanel />);
+
+    expect(screen.getByTestId('tabs')).not.toBeNull();
+    expect(screen.getByTestId('tab-adding')).not.toBeNull();
+    expect(screen.getByTestId('tab-editing')).not.toBeNull();
+  });
+
+  it('renders the adding view by default', () => {
+    render(<TechsEditPanel />);
+
+    expect(screen.getByTestId('view-adding')).not.toBeNull();
+    expect(screen.queryByTestId('view-editing')).toBeNull();
+  });
+
+  it('switches to the editing view when the edit tab is clicked', () => {
+    render(<TechsEditPanel />);
+
+    fireEvent.click(screen.getByTestId('tab-editing'));
+
+    expect(screen.getByTestId('view-editing')).not.toBeNull();
+    expect(screen.queryByTestId('view-adding')).toBeNull();
+  });
+});

--- a/src/features/techs/parser/test.ts
+++ b/src/features/techs/parser/test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+
+import { Sections } from '#/types';
+
+import { techsSectionParser } from '../parser';
+
+const makeIcon = ({
+  name = 'javascript',
+  path = 'https://example.com/js.svg',
+  variants,
+  variantIndex,
+}: {
+  name?: string;
+  path?: string;
+  variants?: string[];
+  variantIndex?: number;
+} = {}) => ({
+  name,
+  color: '#F7DF1E',
+  alias: [],
+  tags: [],
+  available_providers: ['devicons'],
+  providers: {
+    devicons: variants
+      ? { path: path, variants }
+      : { path },
+  },
+  currentProvider: 'devicons',
+  config: variantIndex !== undefined ? { devicons: { variant: variantIndex } } : {},
+});
+
+describe('FEATURE - techs parser', () => {
+  it('emits a div with data-importer="techs"', () => {
+    const result = techsSectionParser({
+      content: {
+        icons: { javascript: makeIcon() as any },
+        styles: { height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain(`data-importer="${Sections.TECHS}"`);
+    expect(result).toContain('<div');
+    expect(result).toContain('</div>');
+  });
+
+  it('includes the align attribute on the wrapper div', () => {
+    const result = techsSectionParser({
+      content: {
+        icons: { javascript: makeIcon() as any },
+        styles: { height: 40 },
+      },
+      styles: { align: 'right', spacing: 12 },
+    });
+
+    expect(result).toContain('align="right"');
+  });
+
+  it('emits one img per icon with the correct src and alt', () => {
+    const result = techsSectionParser({
+      content: {
+        icons: {
+          javascript: makeIcon({ name: 'javascript', path: 'https://example.com/js.svg' }) as any,
+          react: makeIcon({ name: 'react', path: 'https://example.com/react.svg' }) as any,
+        },
+        styles: { height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain('src="https://example.com/js.svg"');
+    expect(result).toContain('alt="javascript logo"');
+    expect(result).toContain('src="https://example.com/react.svg"');
+    expect(result).toContain('alt="react logo"');
+  });
+
+  it('emits spacing images between icons but not after the last one', () => {
+    const result = techsSectionParser({
+      content: {
+        icons: {
+          javascript: makeIcon({ path: 'https://example.com/js.svg' }) as any,
+          react: makeIcon({ path: 'https://example.com/react.svg' }) as any,
+        },
+        styles: { height: 40 },
+      },
+      styles: { align: 'center', spacing: 20 },
+    });
+
+    const spacingCount = (result.match(/<img width="20"\/>/g) || []).length;
+    expect(spacingCount).toBe(1);
+  });
+
+  it('uses the provider path when no variants exist', () => {
+    const result = techsSectionParser({
+      content: {
+        icons: {
+          myicon: makeIcon({ path: 'https://example.com/icon.svg' }) as any,
+        },
+        styles: { height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain('src="https://example.com/icon.svg"');
+  });
+
+  it('uses the variant at the configured index when variants exist', () => {
+    const result = techsSectionParser({
+      content: {
+        icons: {
+          myicon: makeIcon({
+            path: 'https://example.com/original.svg',
+            variants: [
+              'https://example.com/original.svg',
+              'https://example.com/plain.svg',
+            ],
+            variantIndex: 1,
+          }) as any,
+        },
+        styles: { height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain('src="https://example.com/plain.svg"');
+  });
+
+  it('defaults variant index to 0 when not configured', () => {
+    const result = techsSectionParser({
+      content: {
+        icons: {
+          myicon: makeIcon({
+            path: 'https://example.com/original.svg',
+            variants: [
+              'https://example.com/original.svg',
+              'https://example.com/plain.svg',
+            ],
+          }) as any,
+        },
+        styles: { height: 40 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain('src="https://example.com/original.svg"');
+  });
+
+  it('defaults height to 40 when not provided', () => {
+    const result = techsSectionParser({
+      content: {
+        icons: { myicon: makeIcon({ path: 'https://example.com/icon.svg' }) as any },
+        styles: {},
+      } as any,
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain('height="40"');
+  });
+
+  it('uses the provided height', () => {
+    const result = techsSectionParser({
+      content: {
+        icons: { myicon: makeIcon({ path: 'https://example.com/icon.svg' }) as any },
+        styles: { height: 60 },
+      },
+      styles: { align: 'center', spacing: 12 },
+    });
+
+    expect(result).toContain('height="60"');
+  });
+});

--- a/src/features/techs/parser/test.ts
+++ b/src/features/techs/parser/test.ts
@@ -21,12 +21,11 @@ const makeIcon = ({
   tags: [],
   available_providers: ['devicons'],
   providers: {
-    devicons: variants
-      ? { path: path, variants }
-      : { path },
+    devicons: variants ? { path: path, variants } : { path },
   },
   currentProvider: 'devicons',
-  config: variantIndex !== undefined ? { devicons: { variant: variantIndex } } : {},
+  config:
+    variantIndex !== undefined ? { devicons: { variant: variantIndex } } : {},
 });
 
 describe('FEATURE - techs parser', () => {
@@ -60,8 +59,14 @@ describe('FEATURE - techs parser', () => {
     const result = techsSectionParser({
       content: {
         icons: {
-          javascript: makeIcon({ name: 'javascript', path: 'https://example.com/js.svg' }) as any,
-          react: makeIcon({ name: 'react', path: 'https://example.com/react.svg' }) as any,
+          javascript: makeIcon({
+            name: 'javascript',
+            path: 'https://example.com/js.svg',
+          }) as any,
+          react: makeIcon({
+            name: 'react',
+            path: 'https://example.com/react.svg',
+          }) as any,
         },
         styles: { height: 40 },
       },
@@ -148,7 +153,9 @@ describe('FEATURE - techs parser', () => {
   it('defaults height to 40 when not provided', () => {
     const result = techsSectionParser({
       content: {
-        icons: { myicon: makeIcon({ path: 'https://example.com/icon.svg' }) as any },
+        icons: {
+          myicon: makeIcon({ path: 'https://example.com/icon.svg' }) as any,
+        },
         styles: {},
       } as any,
       styles: { align: 'center', spacing: 12 },
@@ -160,7 +167,9 @@ describe('FEATURE - techs parser', () => {
   it('uses the provided height', () => {
     const result = techsSectionParser({
       content: {
-        icons: { myicon: makeIcon({ path: 'https://example.com/icon.svg' }) as any },
+        icons: {
+          myicon: makeIcon({ path: 'https://example.com/icon.svg' }) as any,
+        },
         styles: { height: 60 },
       },
       styles: { align: 'center', spacing: 12 },

--- a/src/features/techs/section/test.tsx
+++ b/src/features/techs/section/test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import { TechsSection } from '../section';
+
+const messages = {
+  ui: {
+    alts: {
+      'tech-logo': '{name} logo',
+    },
+  },
+};
+
+function renderWithProvider(ui: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+const makeIcon = (path: string, variants?: string[], variantIndex?: number) => ({
+  name: 'test',
+  color: '#fff',
+  alias: [],
+  tags: [],
+  available_providers: ['devicons'],
+  providers: {
+    devicons: variants ? { path, variants } : { path },
+  },
+  currentProvider: 'devicons',
+  config: variantIndex !== undefined ? { devicons: { variant: variantIndex } } : {},
+});
+
+describe('FEATURE - TechsSection', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the wrapper div with flex flex-wrap and justify-content from align', () => {
+    const { container } = renderWithProvider(
+      <TechsSection
+        content={{
+          icons: { javascript: makeIcon('https://example.com/js.svg') as any },
+          styles: { height: 40 },
+        }}
+        styles={{ align: 'center', spacing: 12 }}
+      />
+    );
+
+    const wrapper = container.querySelector('.flex');
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).toContain('flex-wrap');
+    expect(wrapper?.getAttribute('style')).toContain('justify-content: center');
+  });
+
+  it('renders one img per icon with the correct src', () => {
+    const { container } = renderWithProvider(
+      <TechsSection
+        content={{
+          icons: {
+            javascript: makeIcon('https://example.com/js.svg') as any,
+            react: makeIcon('https://example.com/react.svg') as any,
+          },
+          styles: { height: 40 },
+        }}
+        styles={{ align: 'center', spacing: 12 }}
+      />
+    );
+
+    const imgs = container.querySelectorAll('img');
+
+    expect(imgs).toHaveLength(2);
+    expect(imgs[0]?.getAttribute('src')).toBe('https://example.com/js.svg');
+    expect(imgs[1]?.getAttribute('src')).toBe('https://example.com/react.svg');
+  });
+
+  it('uses the variant at the configured index when variants exist', () => {
+    const { container } = renderWithProvider(
+      <TechsSection
+        content={{
+          icons: {
+            myicon: makeIcon(
+              'https://example.com/original.svg',
+              ['https://example.com/original.svg', 'https://example.com/plain.svg'],
+              1
+            ) as any,
+          },
+          styles: { height: 40 },
+        }}
+        styles={{ align: 'center', spacing: 12 }}
+      />
+    );
+
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://example.com/plain.svg'
+    );
+  });
+
+  it('applies height as inline style on each img', () => {
+    const { container } = renderWithProvider(
+      <TechsSection
+        content={{
+          icons: { javascript: makeIcon('https://example.com/js.svg') as any },
+          styles: { height: 50 },
+        }}
+        styles={{ align: 'center', spacing: 12 }}
+      />
+    );
+
+    expect(container.querySelector('img')?.style.height).toBe('50px');
+  });
+
+  it('applies spacing as gap on the wrapper div', () => {
+    const { container } = renderWithProvider(
+      <TechsSection
+        content={{
+          icons: { javascript: makeIcon('https://example.com/js.svg') as any },
+          styles: { height: 40 },
+        }}
+        styles={{ align: 'center', spacing: 20 }}
+      />
+    );
+
+    expect(container.querySelector('.flex')?.getAttribute('style')).toContain(
+      'gap: 20px'
+    );
+  });
+});

--- a/src/features/techs/section/test.tsx
+++ b/src/features/techs/section/test.tsx
@@ -20,7 +20,11 @@ function renderWithProvider(ui: React.ReactNode) {
   );
 }
 
-const makeIcon = (path: string, variants?: string[], variantIndex?: number) => ({
+const makeIcon = (
+  path: string,
+  variants?: string[],
+  variantIndex?: number
+) => ({
   name: 'test',
   color: '#fff',
   alias: [],
@@ -30,7 +34,8 @@ const makeIcon = (path: string, variants?: string[], variantIndex?: number) => (
     devicons: variants ? { path, variants } : { path },
   },
   currentProvider: 'devicons',
-  config: variantIndex !== undefined ? { devicons: { variant: variantIndex } } : {},
+  config:
+    variantIndex !== undefined ? { devicons: { variant: variantIndex } } : {},
 });
 
 describe('FEATURE - TechsSection', () => {
@@ -84,7 +89,10 @@ describe('FEATURE - TechsSection', () => {
           icons: {
             myicon: makeIcon(
               'https://example.com/original.svg',
-              ['https://example.com/original.svg', 'https://example.com/plain.svg'],
+              [
+                'https://example.com/original.svg',
+                'https://example.com/plain.svg',
+              ],
               1
             ) as any,
           },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation Update

## What I did

Expanded test coverage to the 7 remaining untested features in `src/features/`, following the per-feature test pattern established by epics #245 and #249 (parser, importer, section, panel, index).

Overall statement coverage increased from **38.6%** to **68.78%**, exceeding the 55% target.

### Features covered

| Feature | Test files | Statement coverage |
| --- | --- | --- |
| activities | parser, importer, section, panel, index | 83.33% |
| snake | parser, importer, section, panel, index | 61.9% |
| pacman | parser, importer, section, panel, index | 75.75% |
| music | parser, importer, section, panel, index | 85.96% |
| techs | parser, importer, section, panel, index | 85.18% |
| socials | parser, importer, section, panel, index | 88.09% |
| stats | parser, importer, section, panel, index | 76.47% |

### Test coverage per feature

- **parser/test.ts** — HTML output assertions (data-importer markers, URLs, branch behavior); workflow parsers tested for snake/pacman/stats
- **importer/test.ts** — null edge cases, happy-path CanvasSection return, config parsing, no shared-default-config mutation
- **section/test.tsx** — rendered markup with mocked url helpers / GuardSection / next-intl
- **panel/test.tsx** — GroupFields count/labels or tab/view switching (mocked leaf components)
- **index/test.tsx** — extensionsStore registration, onClick dispatch, parser/defaultConfig verification

Closes #255
Closes #256
Closes #257
Closes #258
Closes #259
Closes #260
Closes #261
Closes #262

### Verification

- [x] `pnpm test` — 436 tests pass (94 test files), no regressions
- [x] `pnpm lint` — 0 errors, 237 warnings (all `noExplicitAny` in test files, matching existing pattern)
- [x] Coverage — 68.78% statements (target: ≥55%)
- [x] No production code changed — only test files added (35 new files)

### Notes

- All tests follow the existing Vitest + @testing-library/react pattern with `#/...` imports
- Importer tests verify no shared-default-config mutation (same pattern as #251)
- Panel tests for features with views (music, techs, socials, stats) test the shell + view switching, not exhaustive leaf-field rendering
- Stats parser tests cover all 4 workflow parsers (stats, languages, trophy, activity-graph)
- Snake/pacman parser tests cover both readme and workflow parsers

Requested by: @maurodesouza